### PR TITLE
Opam packaging for ocamlmpi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,11 @@ OCAMLC=ocamlc
 OCAMLOPT=ocamlopt
 OCAMLDEP=ocamldep
 
-DESTDIR=`$(OCAMLC) -where`/ocamlmpi
 MPIINCDIR=/usr/include/mpich2
 MPILIBDIR=/usr/lib
+MPICC=mpicc
+MPIRUN=mpirun
 
-CC=mpicc
 CFLAGS=-I`$(OCAMLC) -where` -I$(MPIINCDIR) -O2 -g -Wall
 
 COBJS=init.o comm.o msgs.o collcomm.o groups.o utils.o
@@ -16,6 +16,9 @@ all: libcamlmpi.a byte
 
 install:
 	ocamlfind install mpi META mpi.mli mpi.cmi $(wildcard mpi.cm*a) $(wildcard *mpi.a)
+
+uninstall:
+	ocamlfind remove mpi
 
 libcamlmpi.a: $(COBJS)
 	rm -f $@
@@ -37,16 +40,16 @@ opt: $(OBJS:.cmo=.cmx)
 	$(OCAMLOPT) -c $<
 
 testmpi: test.ml mpi.cma libcamlmpi.a
-	ocamlc -g -o testmpi unix.cma mpi.cma test.ml -ccopt -L.
+	ocamlc -g -o testmpi unix.cma mpi.cma test.ml -ccopt -L$(MPILIBDIR) -ccopt -L.
 
 testmpinb: testnb.ml mpi.cma libcamlmpi.a
-	ocamlc -cc mpicc -g -o testmpinb unix.cma mpi.cma testnb.ml -ccopt -L.
+	ocamlc -cc $(CC) -g -o testmpinb unix.cma mpi.cma testnb.ml -ccopt -L$(MPILIBDIR) -ccopt -L.
 
 clean::
 	rm -f testmpi
 
 test: testmpi
-	mpirun -np 5 ./testmpi
+	$(MPIRUN) -np 5 ./testmpi
 
 test_mandel: test_mandel.ml mpi.cmxa libcamlmpi.a
 	ocamlopt -o test_mandel graphics.cmxa mpi.cmxa test_mandel.ml -ccopt -L.

--- a/README
+++ b/README
@@ -54,13 +54,15 @@ That is:
 
 BUILDING OCAMLMPI:
 
-Edit the Makefile and set the MPIINCDIR and MPILIBDIR
-variables to the right directories:
+Edit the Makefile and set the following variables according to your
+MPI installation:
 
 MPIINCDIR    directory containing the MPI include file <mpi.h>
 MPILIBDIR    directory containing the MPI library -lmpi
+MPICC        path to the 'mpicc' executable
+MPIRUN       path to the 'mpirun' executable
 
-Also adjust CC and CFLAGS if necessary.  Then do "make all" and
+You may also adjust CFLAGS if necessary.  Then do "make all" and
 optionally "make opt" if you want to build the native code library.
 
 For final installation: become super-user and do "make install".

--- a/opam
+++ b/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+maintainer: "xavier.leroy@inria.fr"
+authors: ["Xavier Leroy"]
+homepage: "https://github.com/xavierleroy/ocamlmpi"
+bug-reports: "https://github.com/xavierleroy/ocamlmpi/issues"
+dev-repo: "git://github.com/xavierleroy/ocamlmpi"
+
+build: [
+  [make "all" "opt"
+    "MPIINCDIR=%{conf-mpi:includedir}%"
+    "MPILIBDIR=%{conf-mpi:libdir}%"
+    "MPICC=%{conf-mpi:binpath}%mpicc"
+    "MPIRUN=%{conf-mpi:binpath}%mpirun"
+  ]
+]
+install: [[make "install"]]
+remove: [[make "uninstall"]]
+depends: ["conf-mpi" "ocamlfind"]
+depexts: [
+  [["debian"] ["mpi-default-dev"]]
+  [["ubuntu"] ["mpi-default-dev"]]
+]
+


### PR DESCRIPTION
The "set the relevant variables yourself" style of ocamlmpi installation may look incompatible with opam packaging. There has been an `ocamlmpi` OPAM package maintained by François @UnixJunkie Bérenger (thanks!), but it was broken on many systems, see https://github.com/ocaml/opam-repository/issues/5023, and in fact the opam repository maintainers removed it today.

On the side of the opam-repository, I created a `conf-mpi` package that tries to find where a MPI implementation (openmpi or mpich) is installed, and export its finding as opam package variables. The present PR makes minor changes to the Makefile to make more things changeable (on my Fedora machine none of `mpirun` and `mpicc` are in the PATH, but you only allowed to redefine CC=mpicc), and then provides an `opam` file that uses the `conf-mpi` variables to generate the right build actions.

One can test the opam file with `opam pin add ocamlmpi .` in the directory, which should build and install the package using opam.

If/when this PR gets merged, it would be very helpful if you could "do an ocamlmpi release", that is create a new git tag (1.02?). The previous release (see [github's list](https://github.com/xavierleroy/ocamlmpi/releases)) does not support ocamlfind, so it is unusable for OPAM packaging. Creating and push a new tag would have github create and serve a tarball at a fixed URL, which I could use to create a `mpi` package in the OPAM repository.

Remark: I renamed the variable `CC` into `MPICC` for consistency: what the user should define is `MPIINCDIR`, `MPILIBDIR`, `MPICC` and `MPIRUN`. (What the configuration-detection actually determines is `MPIBINPATH`, and it sets `MPICC=${MPIBINPATH}mpicc` and `MPIRUN=${MPIBINPATH}mpicc`, but in general a user may have them in different directories?). If you expect the renaming `CC`->`MPICC` to be an issue, I can revert back (do you remember the wizard bash trick to say "use this variable if defined and otherwise..."?).