### PR TITLE
Eliminate deprecated warnings for error handlers

### DIFF
--- a/init.c
+++ b/init.c
@@ -57,8 +57,14 @@ value caml_mpi_init(value arguments)
   argv[i] = NULL;
   MPI_Init(&argc, &argv);
   /* Register an error handler */
+#if MPI_VERSION >= 2
+  MPI_Comm_create_errhandler(
+	  (MPI_Handler_function *)caml_mpi_error_handler, &hdlr);
+  MPI_Comm_set_errhandler(MPI_COMM_WORLD, hdlr);
+#else
   MPI_Errhandler_create((MPI_Handler_function *)caml_mpi_error_handler, &hdlr);
   MPI_Errhandler_set(MPI_COMM_WORLD, hdlr);
+#endif
   return Val_unit;
 }
 


### PR DESCRIPTION
MPI_Errhandler_create is renamed to MPI_Comm_create_errhandler in MPI-2:
https://www.open-mpi.org/doc/v3.0/man3/MPI_Errhandler_create.3.php

MPI_Errhandler_set is renamed to MPI_Comm_set_errhandler in MPI-2:
https://www.open-mpi.org/doc/v3.0/man3/MPI_Errhandler_set.3.php