### PR TITLE
Add support for bigarrays

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,10 +41,10 @@ opt: $(OBJS:.cmo=.cmx)
 	$(OCAMLOPT) -c $<
 
 testmpi: test.ml mpi.cma libcamlmpi.a
-	ocamlc -g -o testmpi unix.cma mpi.cma test.ml -ccopt -L$(MPILIBDIR) -ccopt -L.
+	ocamlc -g -o testmpi unix.cma bigarray.cma mpi.cma test.ml -ccopt -L$(MPILIBDIR) -ccopt -L.
 
 testmpinb: testnb.ml mpi.cma libcamlmpi.a
-	ocamlc -cc $(CC) -g -o testmpinb unix.cma mpi.cma testnb.ml -ccopt -L$(MPILIBDIR) -ccopt -L.
+	ocamlc -cc $(CC) -g -o testmpinb unix.cma bigarray.cma mpi.cma testnb.ml -ccopt -L$(MPILIBDIR) -ccopt -L.
 
 clean::
 	rm -f testmpi

--- a/camlmpi.h
+++ b/camlmpi.h
@@ -25,6 +25,17 @@ extern value caml_mpi_alloc_comm(MPI_Comm c);
 extern void caml_mpi_decode_intarray(value array, mlsize_t len);
 extern void caml_mpi_encode_intarray(value array, mlsize_t len);
 
+extern MPI_Datatype caml_mpi_ba_mpi_type[];
+
+// declare big enough for int64, float64, complex64 (two doubles)
+#define any_ba_value(x) double (x)[2]
+
+// transform a bigarray element into an OCaml value
+value caml_mpi_ba_value(any_ba_value(dv), intnat kind);
+// transform an OCaml value into a bigarray element
+void caml_mpi_ba_element(value dv, intnat kind, any_ba_value(rv));
+// integer kind: returns 0; floating-point kind: returns 1
+
 #ifdef ARCH_ALIGN_DOUBLE
 
 extern double * caml_mpi_input_floatarray(value data, mlsize_t len);

--- a/camlmpi.h
+++ b/camlmpi.h
@@ -20,6 +20,7 @@
 #define Request_req_val(req) (*((MPI_Request *) &Field(req, 1)))
 #define Buffer_req_val(req)   (*((char **) &Field(req, 2)))
 
+extern void caml_mpi_raise_error(const char *msg);
 extern value caml_mpi_alloc_comm(MPI_Comm c);
 
 extern void caml_mpi_decode_intarray(value array, mlsize_t len);

--- a/collcomm.c
+++ b/collcomm.c
@@ -19,6 +19,7 @@
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
 #include <caml/alloc.h>
+#include <caml/bigarray.h>
 #include "camlmpi.h"
 
 /* Barrier synchronization */
@@ -65,6 +66,16 @@ value caml_mpi_broadcast_floatarray(value data, value root, value comm)
   double * d = caml_mpi_input_floatarray(data, len);
   MPI_Bcast(d, len, MPI_DOUBLE, Int_val(root), Comm_val(comm));
   caml_mpi_commit_floatarray(d, data, len);
+  return Val_unit;
+}
+
+value caml_mpi_broadcast_bigarray(value data, value root, value comm)
+{
+  struct caml_ba_array* d = Caml_ba_array_val(data);
+  mlsize_t len = d->dim[0];
+  MPI_Datatype dt = caml_mpi_ba_mpi_type[d->flags & CAML_BA_KIND_MASK];
+
+  MPI_Bcast(d->data, len, dt, Int_val(root), Comm_val(comm));
   return Val_unit;
 }
 
@@ -129,6 +140,21 @@ value caml_mpi_scatter_float(value data, value root, value comm)
   return caml_copy_double(dst);
 }
 
+CAMLprim value caml_mpi_scatter_from_bigarray(value data, value root,
+					      value comm)
+{
+  CAMLparam3(data, root, comm);
+  struct caml_ba_array* d = Caml_ba_array_val(data);
+  intnat kind = d->flags & CAML_BA_KIND_MASK;
+  MPI_Datatype dt = caml_mpi_ba_mpi_type[kind];
+
+  any_ba_value(dst);
+  MPI_Scatter(d->data, 1, dt, &dst, 1, dt,
+              Int_val(root), Comm_val(comm));
+
+  CAMLreturn(caml_mpi_ba_value(dst, kind));
+}
+
 value caml_mpi_scatter_intarray(value source, value dest,
                                 value root, value comm)
 {
@@ -151,6 +177,19 @@ value caml_mpi_scatter_floatarray(value source, value dest,
               Int_val(root), Comm_val(comm));
   caml_mpi_free_floatarray(src);
   caml_mpi_commit_floatarray(dst, dest, len);
+  return Val_unit;
+}
+
+value caml_mpi_scatter_bigarray(value source, value dest,
+                                value root, value comm)
+{
+  struct caml_ba_array* s = Caml_ba_array_val(source);
+  struct caml_ba_array* d = Caml_ba_array_val(dest);
+  mlsize_t len = d->dim[0];
+  MPI_Datatype dt = caml_mpi_ba_mpi_type[d->flags & CAML_BA_KIND_MASK];
+
+  MPI_Scatter(s->data, len, dt, d->data, len, dt,
+              Int_val(root), Comm_val(comm));
   return Val_unit;
 }
 
@@ -205,6 +244,34 @@ value caml_mpi_gather_float(value data, value result, value root, value comm)
   return Val_unit;
 }
 
+CAMLprim value caml_mpi_gather_to_bigarray(value data, value result,
+				           value root, value comm)
+{
+  CAMLparam4(data, result, root, comm);
+  struct caml_ba_array* r = Caml_ba_array_val(result);
+  intnat kind = r->flags & CAML_BA_KIND_MASK;
+  MPI_Datatype dt = caml_mpi_ba_mpi_type[kind];
+
+  any_ba_value(d);
+  caml_mpi_ba_element(data, kind, d);
+
+  MPI_Gather(d, 1, dt, r->data, 1, dt, Int_val(root), Comm_val(comm));
+  CAMLreturn(Val_unit);
+}
+
+value caml_mpi_gather_bigarray(value data, value result,
+			       value root, value comm)
+{
+  struct caml_ba_array* d = Caml_ba_array_val(data);
+  struct caml_ba_array* r = Caml_ba_array_val(result);
+  mlsize_t len = d->dim[0];
+  MPI_Datatype dt = caml_mpi_ba_mpi_type[r->flags & CAML_BA_KIND_MASK];
+
+  MPI_Gather(d->data, len, dt, r->data, len, dt,
+	     Int_val(root), Comm_val(comm));
+  return Val_unit;
+}
+
 /* Gather to all */
 
 value caml_mpi_allgather(value sendbuf,
@@ -250,6 +317,32 @@ value caml_mpi_allgather_float(value data, value result, value comm)
                 Comm_val(comm));
   caml_mpi_free_floatarray(d);
   caml_mpi_commit_floatarray(res, result, reslen);
+  return Val_unit;
+}
+
+CAMLprim value caml_mpi_allgather_to_bigarray(value data, value result,
+					      value comm)
+{
+  CAMLparam3(data, result, comm);
+  struct caml_ba_array* r = Caml_ba_array_val(result);
+  intnat kind = r->flags & CAML_BA_KIND_MASK;
+  MPI_Datatype dt = caml_mpi_ba_mpi_type[kind];
+
+  any_ba_value(d);
+  caml_mpi_ba_element(data, kind, d);
+
+  MPI_Allgather(d, 1, dt, r->data, 1, dt, Comm_val(comm));
+  CAMLreturn(Val_unit);
+}
+
+value caml_mpi_allgather_bigarray(value data, value result, value comm)
+{
+  struct caml_ba_array* d = Caml_ba_array_val(data);
+  struct caml_ba_array* r = Caml_ba_array_val(result);
+  mlsize_t len = d->dim[0];
+  MPI_Datatype dt = caml_mpi_ba_mpi_type[r->flags & CAML_BA_KIND_MASK];
+
+  MPI_Allgather(d->data, len, dt, r->data, len, dt, Comm_val(comm));
   return Val_unit;
 }
 
@@ -310,6 +403,19 @@ value caml_mpi_reduce_floatarray(value data, value result, value op,
   return Val_unit;
 }
 
+value caml_mpi_reduce_bigarray(value data, value result, value op,
+                               value root, value comm)
+{
+  struct caml_ba_array* d = Caml_ba_array_val(data);
+  struct caml_ba_array* r = Caml_ba_array_val(result);
+  mlsize_t len = d->dim[0];
+  MPI_Datatype dt = caml_mpi_ba_mpi_type[d->flags & CAML_BA_KIND_MASK];
+
+  MPI_Reduce(d->data, r->data, len, dt,
+             reduce_intop[Int_val(op)], Int_val(root), Comm_val(comm));
+  return Val_unit;
+}
+
 /* Allreduce */
 
 value caml_mpi_allreduce_int(value data, value op, value comm)
@@ -360,6 +466,19 @@ value caml_mpi_allreduce_floatarray(value data, value result, value op,
   return Val_unit;
 }
 
+value caml_mpi_allreduce_bigarray(value data, value result, value op,
+                                  value comm)
+{
+  struct caml_ba_array* d = Caml_ba_array_val(data);
+  struct caml_ba_array* r = Caml_ba_array_val(result);
+  mlsize_t len = d->dim[0];
+  MPI_Datatype dt = caml_mpi_ba_mpi_type[d->flags & CAML_BA_KIND_MASK];
+
+  MPI_Allreduce(d->data, r->data, len, dt,
+                reduce_intop[Int_val(op)], Comm_val(comm));
+  return Val_unit;
+}
+
 /* Scan */
 
 value caml_mpi_scan_int(value data, value op, value comm)
@@ -406,6 +525,18 @@ value caml_mpi_scan_floatarray(value data, value result, value op, value comm)
            reduce_floatop[Int_val(op)], Comm_val(comm));
   caml_mpi_free_floatarray(d);
   caml_mpi_commit_floatarray(res, result, len);
+  return Val_unit;
+}
+
+value caml_mpi_scan_bigarray(value data, value result, value op, value comm)
+{
+  struct caml_ba_array* d = Caml_ba_array_val(data);
+  struct caml_ba_array* r = Caml_ba_array_val(result);
+  mlsize_t len = d->dim[0];
+  MPI_Datatype dt = caml_mpi_ba_mpi_type[d->flags & CAML_BA_KIND_MASK];
+
+  MPI_Scan(d->data, r->data, len, dt,
+           reduce_intop[Int_val(op)], Comm_val(comm));
   return Val_unit;
 }
 

--- a/collcomm.c
+++ b/collcomm.c
@@ -470,17 +470,19 @@ value caml_mpi_alltoall_bigarray(value data, value result, value comm)
 
 /* Reduce */
 
-static MPI_Op reduce_intop[] =
-  { MPI_MAX, MPI_MIN, MPI_SUM, MPI_PROD, MPI_BAND, MPI_BOR, MPI_BXOR };
-static MPI_Op reduce_floatop[] =
-  { MPI_MAX, MPI_MIN, MPI_SUM, MPI_PROD };
+static MPI_Op reduce_op[] =
+  { MPI_MAX, MPI_MIN, MPI_SUM, MPI_PROD, MPI_BAND, MPI_BOR, MPI_BXOR,
+    // deprecated Int_* ops:
+    MPI_MAX, MPI_MIN, MPI_SUM, MPI_PROD, MPI_BAND, MPI_BOR, MPI_BXOR,
+    // deprecated Float_* ops:
+    MPI_MAX, MPI_MIN, MPI_SUM, MPI_PROD };
 
 value caml_mpi_reduce_int(value data, value op, value root, value comm)
 {
   long d = Long_val(data);
   long r = 0;
   MPI_Reduce(&d, &r, 1, MPI_LONG,
-             reduce_intop[Int_val(op)], Int_val(root), Comm_val(comm));
+             reduce_op[Int_val(op)], Int_val(root), Comm_val(comm));
   return Val_long(r);
 }
 
@@ -493,7 +495,7 @@ value caml_mpi_reduce_intarray(value data, value result, value op,
   caml_mpi_decode_intarray(data, len);
   /* Do the reduce */
   MPI_Reduce(&Field(data, 0), &Field(result, 0), len, MPI_LONG,
-             reduce_intop[Int_val(op)], Int_val(root), Comm_val(comm));
+             reduce_op[Int_val(op)], Int_val(root), Comm_val(comm));
   /* Re-encode data at all nodes in place */
   caml_mpi_encode_intarray(data, len);
   /* At root node, also encode result */
@@ -507,7 +509,7 @@ value caml_mpi_reduce_float(value data, value op, value root, value comm)
   double d = Double_val(data);
   double r = 0.0;
   MPI_Reduce(&d, &r, 1, MPI_DOUBLE,
-             reduce_floatop[Int_val(op)], Int_val(root), Comm_val(comm));
+             reduce_op[Int_val(op)], Int_val(root), Comm_val(comm));
   return caml_copy_double(r);
 }
 
@@ -519,7 +521,7 @@ value caml_mpi_reduce_floatarray(value data, value result, value op,
   double * res = caml_mpi_output_floatarray(result, len);
 
   MPI_Reduce(d, res, len, MPI_DOUBLE,
-             reduce_floatop[Int_val(op)], Int_val(root), Comm_val(comm));
+             reduce_op[Int_val(op)], Int_val(root), Comm_val(comm));
   caml_mpi_free_floatarray(d);
   caml_mpi_commit_floatarray(res, result, len);
   return Val_unit;
@@ -545,7 +547,7 @@ value caml_mpi_reduce_bigarray(value data, value result, value op,
   }
 
   MPI_Reduce(sendbuf, r->data, dlen, dt,
-             reduce_intop[Int_val(op)], Int_val(root), c);
+             reduce_op[Int_val(op)], Int_val(root), c);
   return Val_unit;
 }
 
@@ -556,7 +558,7 @@ value caml_mpi_allreduce_int(value data, value op, value comm)
   long d = Long_val(data);
   long r;
   MPI_Allreduce(&d, &r, 1, MPI_LONG,
-                reduce_intop[Int_val(op)], Comm_val(comm));
+                reduce_op[Int_val(op)], Comm_val(comm));
   return Val_long(r);
 }
 
@@ -568,7 +570,7 @@ value caml_mpi_allreduce_intarray(value data, value result, value op,
   caml_mpi_decode_intarray(data, len);
   /* Do the reduce */
   MPI_Allreduce(&Field(data, 0), &Field(result, 0), len, MPI_LONG,
-                reduce_intop[Int_val(op)], Comm_val(comm));
+                reduce_op[Int_val(op)], Comm_val(comm));
   /* Re-encode data at all nodes in place */
   caml_mpi_encode_intarray(data, len);
   /* Re-encode result at all nodes in place */
@@ -581,7 +583,7 @@ value caml_mpi_allreduce_float(value data, value op, value comm)
   double d = Double_val(data);
   double r;
   MPI_Allreduce(&d, &r, 1, MPI_DOUBLE,
-                reduce_floatop[Int_val(op)], Comm_val(comm));
+                reduce_op[Int_val(op)], Comm_val(comm));
   return caml_copy_double(r);
 }
 
@@ -593,7 +595,7 @@ value caml_mpi_allreduce_floatarray(value data, value result, value op,
   double * res = caml_mpi_output_floatarray(result, len);
 
   MPI_Allreduce(d, res, len, MPI_DOUBLE,
-                reduce_floatop[Int_val(op)], Comm_val(comm));
+                reduce_op[Int_val(op)], Comm_val(comm));
   caml_mpi_free_floatarray(d);
   caml_mpi_commit_floatarray(res, result, len);
   return Val_unit;
@@ -612,7 +614,7 @@ value caml_mpi_allreduce_bigarray(value data, value result, value op,
     caml_mpi_raise_error("Mpi.allreduce_bigarray: array size mismatch");
 
   MPI_Allreduce(sendbuf, r->data, dlen, dt,
-		reduce_intop[Int_val(op)], Comm_val(comm));
+		reduce_op[Int_val(op)], Comm_val(comm));
   return Val_unit;
 }
 
@@ -623,7 +625,7 @@ value caml_mpi_scan_int(value data, value op, value comm)
   long d = Long_val(data);
   long r;
 
-  MPI_Scan(&d, &r, 1, MPI_LONG, reduce_intop[Int_val(op)], Comm_val(comm));
+  MPI_Scan(&d, &r, 1, MPI_LONG, reduce_op[Int_val(op)], Comm_val(comm));
   return Val_long(r);
 }
 
@@ -635,7 +637,7 @@ value caml_mpi_scan_intarray(value data, value result, value op, value comm)
   caml_mpi_decode_intarray(data, len);
   /* Do the scan */
   MPI_Scan(&Field(data, 0), &Field(result, 0), len, MPI_LONG,
-           reduce_intop[Int_val(op)], Comm_val(comm));
+           reduce_op[Int_val(op)], Comm_val(comm));
   /* Re-encode data at all nodes in place */
   caml_mpi_encode_intarray(data, len);
   /* Encode result */
@@ -648,7 +650,7 @@ value caml_mpi_scan_float(value data, value op, value comm)
   double d = Double_val(data), r;
 
   MPI_Scan(&d, &r, 1, MPI_DOUBLE,
-           reduce_floatop[Int_val(op)], Comm_val(comm));
+           reduce_op[Int_val(op)], Comm_val(comm));
   return caml_copy_double(r);
 }
 
@@ -659,7 +661,7 @@ value caml_mpi_scan_floatarray(value data, value result, value op, value comm)
   double * res = caml_mpi_output_floatarray(result, len);
 
   MPI_Scan(d, res, len, MPI_DOUBLE,
-           reduce_floatop[Int_val(op)], Comm_val(comm));
+           reduce_op[Int_val(op)], Comm_val(comm));
   caml_mpi_free_floatarray(d);
   caml_mpi_commit_floatarray(res, result, len);
   return Val_unit;
@@ -677,7 +679,7 @@ value caml_mpi_scan_bigarray(value data, value result, value op, value comm)
     caml_mpi_raise_error("Mpi.scan_bigarray: array size mismatch");
 
   MPI_Scan(sendbuf, r->data, dlen, dt,
-           reduce_intop[Int_val(op)], Comm_val(comm));
+           reduce_op[Int_val(op)], Comm_val(comm));
   return Val_unit;
 }
 

--- a/init.c
+++ b/init.c
@@ -43,6 +43,18 @@ static void caml_mpi_error_handler(MPI_Comm * comm, int * errcode, ...)
   caml_raise_with_arg(*caml_mpi_exn, msg);
 }
 
+/* Bigarrays */
+
+MPI_Datatype caml_mpi_ba_mpi_type[] =
+{ MPI_FLOAT /*FLOAT32*/, MPI_DOUBLE /*FLOAT64*/,
+  MPI_INT8_T /*SINT8*/, MPI_UINT8_T /*UINT8*/,
+  MPI_INT16_T /*SINT16*/, MPI_UINT16_T /*UINT16*/,
+  MPI_INT32_T /*INT32*/, MPI_INT64_T /*INT64*/,
+  MPI_LONG /*CAML_INT*/, MPI_LONG /*NATIVE_INT*/,
+  MPI_C_FLOAT_COMPLEX /*COMPLEX32*/, MPI_C_DOUBLE_COMPLEX /*COMPLEX64*/,
+  MPI_CHAR /*CHAR*/
+};
+
 /* Initialization and finalization */
 
 value caml_mpi_init(value arguments)
@@ -65,6 +77,7 @@ value caml_mpi_init(value arguments)
   MPI_Errhandler_create((MPI_Handler_function *)caml_mpi_error_handler, &hdlr);
   MPI_Errhandler_set(MPI_COMM_WORLD, hdlr);
 #endif
+
   return Val_unit;
 }
 

--- a/init.c
+++ b/init.c
@@ -43,6 +43,16 @@ static void caml_mpi_error_handler(MPI_Comm * comm, int * errcode, ...)
   caml_raise_with_arg(*caml_mpi_exn, msg);
 }
 
+void caml_mpi_raise_error(const char *msg)
+{
+  if (caml_mpi_exn == NULL) {
+    caml_mpi_exn = caml_named_value("Mpi.Error");
+    if (caml_mpi_exn == NULL)
+      caml_invalid_argument("Exception MPI.Error not initialized");
+  }
+  caml_raise_with_string(*caml_mpi_exn, msg);
+}
+
 /* Bigarrays */
 
 MPI_Datatype caml_mpi_ba_mpi_type[] =

--- a/mpi.ml
+++ b/mpi.ml
@@ -18,8 +18,6 @@
 
 exception Error of string
 
-type ('a, 'b) ba1 = ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
-
 let ba_kind_is_float (type a b) (k : (a, b) Bigarray.kind) =
   let open Bigarray in
   match k with
@@ -157,11 +155,21 @@ external receive_float_array:
     = "caml_mpi_receive_floatarray"
 
 external send_bigarray:
-    ('a, 'b) ba1 -> rank -> tag -> communicator -> unit
+    ('a, 'b, 'c) Bigarray.Genarray.t -> rank -> tag -> communicator -> unit
     = "caml_mpi_send_bigarray"
 external receive_bigarray:
-    ('a, 'b) ba1 -> rank -> tag -> communicator -> unit
+    ('a, 'b, 'c) Bigarray.Genarray.t -> rank -> tag -> communicator -> unit
     = "caml_mpi_receive_bigarray"
+
+let send_bigarray0 x = send_bigarray (Bigarray.(genarray_of_array0 x))
+let send_bigarray1 x = send_bigarray (Bigarray.(genarray_of_array1 x))
+let send_bigarray2 x = send_bigarray (Bigarray.(genarray_of_array2 x))
+let send_bigarray3 x = send_bigarray (Bigarray.(genarray_of_array3 x))
+
+let receive_bigarray0 x = receive_bigarray (Bigarray.(genarray_of_array0 x))
+let receive_bigarray1 x = receive_bigarray (Bigarray.(genarray_of_array1 x))
+let receive_bigarray2 x = receive_bigarray (Bigarray.(genarray_of_array2 x))
+let receive_bigarray3 x = receive_bigarray (Bigarray.(genarray_of_array3 x))
 
 (* Non-blocking communication *)
 
@@ -247,8 +255,13 @@ external broadcast_float_array:
     float array -> rank -> communicator -> unit
     = "caml_mpi_broadcast_floatarray"
 external broadcast_bigarray:
-    ('a, 'b) ba1 -> rank -> communicator -> unit
+    ('a, 'b, 'c) Bigarray.Genarray.t -> rank -> communicator -> unit
     = "caml_mpi_broadcast_bigarray"
+
+let broadcast_bigarray0 x = broadcast_bigarray (Bigarray.(genarray_of_array0 x))
+let broadcast_bigarray1 x = broadcast_bigarray (Bigarray.(genarray_of_array1 x))
+let broadcast_bigarray2 x = broadcast_bigarray (Bigarray.(genarray_of_array2 x))
+let broadcast_bigarray3 x = broadcast_bigarray (Bigarray.(genarray_of_array3 x))
 
 (* Scatter *)
 
@@ -303,13 +316,15 @@ external scatter_float:
     = "caml_mpi_scatter_float"
 
 external scatter_from_bigarray:
-    ('a, 'b) ba1 -> rank -> communicator -> 'a
+    ('a, 'b, 'c) Bigarray.Genarray.t -> rank -> communicator -> 'a
     = "caml_mpi_scatter_from_bigarray"
-let scatter_from_bigarray src rank comm =
-  if rank = comm_rank comm
-  && Bigarray.Array1.dim src <> comm_size comm
-  then mpi_error "Mpi.scatter_from_bigarray: array size mismatch"
-  else scatter_from_bigarray src rank comm
+
+let scatter_from_bigarray1 x =
+  scatter_from_bigarray (Bigarray.(genarray_of_array1 x))
+let scatter_from_bigarray2 x =
+  scatter_from_bigarray (Bigarray.(genarray_of_array2 x))
+let scatter_from_bigarray3 x =
+  scatter_from_bigarray (Bigarray.(genarray_of_array3 x))
 
 external scatter_int_array:
     int array -> int array -> rank -> communicator -> unit
@@ -330,13 +345,12 @@ let scatter_float_array src dst rank comm =
   else scatter_float_array src dst rank comm
 
 external scatter_bigarray:
-    ('a, 'b) ba1 -> ('a, 'b) ba1 -> rank -> communicator -> unit
+    ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+    -> rank -> communicator -> unit
     = "caml_mpi_scatter_bigarray"
-let scatter_bigarray src dst rank comm =
-  if rank = comm_rank comm
-  && Bigarray.Array1.dim src <> Bigarray.Array1.dim dst * comm_size comm
-  then mpi_error "Mpi.scatter_bigarray: array size mismatch"
-  else scatter_bigarray src dst rank comm
+
+let scatter_bigarray1 s d = scatter_bigarray (Bigarray.(genarray_of_array1 s))
+                                             (Bigarray.(genarray_of_array1 d))
 
 (* Gather *)
 
@@ -394,13 +408,15 @@ let gather_float src dst rank comm =
   else gather_float src dst rank comm
 
 external gather_to_bigarray:
-    'a -> ('a, 'b) ba1 -> rank -> communicator -> unit
+    'a -> ('a, 'b, 'c) Bigarray.Genarray.t -> rank -> communicator -> unit
     = "caml_mpi_gather_to_bigarray"
-let gather_to_bigarray src dst rank comm =
-  if rank = comm_rank comm
-  && Bigarray.Array1.dim dst <> comm_size comm
-  then mpi_error "Mpi.gather_to_bigarray: array size mismatch"
-  else gather_to_bigarray src dst rank comm
+
+let gather_to_bigarray1 s d =
+  gather_to_bigarray s (Bigarray.(genarray_of_array1 d))
+let gather_to_bigarray2 s d =
+  gather_to_bigarray s (Bigarray.(genarray_of_array2 d))
+let gather_to_bigarray3 s d =
+  gather_to_bigarray s (Bigarray.(genarray_of_array3 d))
 
 external gather_int_array:
     int array -> int array -> rank -> communicator -> unit
@@ -421,13 +437,12 @@ let gather_float_array src dst rank comm =
   else gather_float_array src dst rank comm
 
 external gather_bigarray:
-    ('a, 'b) ba1 -> ('a, 'b) ba1 -> rank -> communicator -> unit
+    ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+    -> rank -> communicator -> unit
     = "caml_mpi_gather_bigarray"
-let gather_bigarray src dst rank comm =
-  if rank = comm_rank comm
-  && Bigarray.Array1.dim dst <> Bigarray.Array1.dim src * comm_size comm
-  then mpi_error "Mpi.gather_bigarray: array size mismatch"
-  else gather_bigarray src dst rank comm
+
+let gather_bigarray1 s d = gather_bigarray (Bigarray.(genarray_of_array1 s))
+                                           (Bigarray.(genarray_of_array1 d))
 
 (* Gather to all *)
 
@@ -473,12 +488,15 @@ let allgather_float src dst comm =
   else allgather_float src dst comm
 
 external allgather_to_bigarray:
-    'a -> ('a, 'b) ba1 -> communicator -> unit
+    'a -> ('a, 'b, 'c) Bigarray.Genarray.t -> communicator -> unit
     = "caml_mpi_allgather_to_bigarray"
-let allgather_to_bigarray src dst comm =
-  if Bigarray.Array1.dim dst <> comm_size comm
-  then mpi_error "MPI.allgather_to_bigarray: array size mismatch"
-  else allgather_to_bigarray src dst comm
+
+let allgather_to_bigarray1 s d =
+  allgather_to_bigarray s (Bigarray.(genarray_of_array1 d))
+let allgather_to_bigarray2 s d =
+  allgather_to_bigarray s (Bigarray.(genarray_of_array2 d))
+let allgather_to_bigarray3 s d =
+  allgather_to_bigarray s (Bigarray.(genarray_of_array3 d))
 
 external allgather_int_array:
     int array -> int array -> communicator -> unit
@@ -497,13 +515,13 @@ let allgather_float_array src dst comm =
   else allgather_float_array src dst comm
 
 external allgather_bigarray:
-    ('a, 'b) ba1 -> ('a, 'b) ba1 -> communicator -> unit
+    ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+    -> communicator -> unit
     = "caml_mpi_allgather_bigarray"
-let allgather_bigarray src dst comm =
-  if Bigarray.Array1.dim dst <> Bigarray.Array1.dim src * comm_size comm
-  then mpi_error "MPI.allgather_bigarray: array size mismatch"
-  else allgather_bigarray src dst comm
 
+let allgather_bigarray1 s d =
+  allgather_bigarray (Bigarray.(genarray_of_array1 s))
+                     (Bigarray.(genarray_of_array1 d))
 (* Reduce *)
 
 type intop =
@@ -539,15 +557,24 @@ let reduce_float_array src dst op rank comm =
   else reduce_float_array src dst op rank comm
 
 external reduce_bigarray:
-    ('a, 'b) ba1 -> ('a, 'b) ba1 -> intop -> rank -> communicator -> unit
+    ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+    -> intop -> rank -> communicator -> unit
     = "caml_mpi_reduce_bigarray"
+
 let reduce_bigarray src dst op rank comm =
-  if rank = comm_rank comm && Bigarray.Array1.dim src <> Bigarray.Array1.dim dst
-  then mpi_error "Mpi.reduce_bigarray: array size mismatch";
-  if ba_kind_is_float (Bigarray.Array1.kind src)
+  if ba_kind_is_float (Bigarray.Genarray.kind src)
      && is_not_also_floatop op
   then mpi_error "Mpi.reduce_bigarray: invalid floating-point operation"
   else reduce_bigarray src dst op rank comm
+
+let reduce_bigarray0 s d = reduce_bigarray (Bigarray.(genarray_of_array0 s))
+                                           (Bigarray.(genarray_of_array0 d))
+let reduce_bigarray1 s d = reduce_bigarray (Bigarray.(genarray_of_array1 s))
+                                           (Bigarray.(genarray_of_array1 d))
+let reduce_bigarray2 s d = reduce_bigarray (Bigarray.(genarray_of_array2 s))
+                                           (Bigarray.(genarray_of_array2 d))
+let reduce_bigarray3 s d = reduce_bigarray (Bigarray.(genarray_of_array3 s))
+                                           (Bigarray.(genarray_of_array3 d))
 
 (* Reduce at all nodes *)
 
@@ -574,15 +601,27 @@ let allreduce_float_array src dst op comm =
   else allreduce_float_array src dst op comm
 
 external allreduce_bigarray:
-    ('a, 'b) ba1 -> ('a, 'b) ba1 -> intop -> communicator -> unit
+    ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+    -> intop -> communicator -> unit
     = "caml_mpi_allreduce_bigarray"
 let allreduce_bigarray src dst op comm =
-  if Bigarray.Array1.dim src <> Bigarray.Array1.dim dst
-  then mpi_error "Mpi.allreduce_bigarray: array size mismatch";
-  if ba_kind_is_float (Bigarray.Array1.kind src)
+  if ba_kind_is_float (Bigarray.Genarray.kind src)
      && is_not_also_floatop op
   then mpi_error "Mpi.allreduce_bigarray: invalid floating-point operation"
   else allreduce_bigarray src dst op comm
+
+let allreduce_bigarray0 s d =
+  allreduce_bigarray (Bigarray.(genarray_of_array0 s))
+                     (Bigarray.(genarray_of_array0 d))
+let allreduce_bigarray1 s d =
+  allreduce_bigarray (Bigarray.(genarray_of_array1 s))
+                     (Bigarray.(genarray_of_array1 d))
+let allreduce_bigarray2 s d =
+  allreduce_bigarray (Bigarray.(genarray_of_array2 s))
+                     (Bigarray.(genarray_of_array2 d))
+let allreduce_bigarray3 s d =
+  allreduce_bigarray (Bigarray.(genarray_of_array3 s))
+                     (Bigarray.(genarray_of_array3 d))
 
 (* Scan *)
 
@@ -611,15 +650,23 @@ let scan_float_array src dst op comm =
   else scan_float_array src dst op comm
 
 external scan_bigarray:
-    ('a, 'b) ba1 -> ('a, 'b) ba1 -> intop -> communicator -> unit
+    ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+    -> intop -> communicator -> unit
     = "caml_mpi_scan_bigarray"
 let scan_bigarray src dst op comm =
-  if Bigarray.Array1.dim dst <> Bigarray.Array1.dim src
-  then mpi_error "Mpi.scan_bigarray: array size mismatch";
-  if ba_kind_is_float (Bigarray.Array1.kind src)
+  if ba_kind_is_float (Bigarray.Genarray.kind src)
      && is_not_also_floatop op
   then mpi_error "Mpi.scan_bigarray: invalid floating-point operation"
   else scan_bigarray src dst op comm
+
+let scan_bigarray0 s d = scan_bigarray (Bigarray.(genarray_of_array0 s))
+                                       (Bigarray.(genarray_of_array0 d))
+let scan_bigarray1 s d = scan_bigarray (Bigarray.(genarray_of_array1 s))
+                                       (Bigarray.(genarray_of_array1 d))
+let scan_bigarray2 s d = scan_bigarray (Bigarray.(genarray_of_array2 s))
+                                       (Bigarray.(genarray_of_array2 d))
+let scan_bigarray3 s d = scan_bigarray (Bigarray.(genarray_of_array3 s))
+                                       (Bigarray.(genarray_of_array3 d))
 
 (*** Process group management *)
 

--- a/mpi.ml
+++ b/mpi.ml
@@ -617,15 +617,6 @@ type _ op =
   | Float_sum  : [< `Float ] op
   | Float_prod : [< `Float ] op
 
-(* Only works for 4.08.0 <= OCaml *)
-let is_int_only_op (type t) (x : t op) =
-  match x with
-  | Max | Min | Sum | Prod -> false
-  | Land | Lor | Xor -> true
-  | Float_max | Float_min | Float_sum | Float_prod -> false
-  | Int_max | Int_min | Int_sum | Int_prod
-  | Int_land | Int_lor | Int_xor -> true
-
 external reduce_int:
   int -> [`Int] op -> rank -> communicator -> int
     = "caml_mpi_reduce_int"
@@ -653,11 +644,6 @@ external reduce_bigarray:
     ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
     -> 'any op -> rank -> communicator -> unit
     = "caml_mpi_reduce_bigarray"
-
-let reduce_bigarray src dst op rank comm =
-  if ba_kind_is_float (Bigarray.Genarray.kind src) && is_int_only_op op
-  then mpi_error "Mpi.reduce_bigarray: invalid floating-point operation"
-  else reduce_bigarray src dst op rank comm
 
 let reduce_bigarray0 s d = reduce_bigarray (Bigarray.(genarray_of_array0 s))
                                            (Bigarray.(genarray_of_array0 d))
@@ -696,10 +682,6 @@ external allreduce_bigarray:
     ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
     -> 'any op -> communicator -> unit
     = "caml_mpi_allreduce_bigarray"
-let allreduce_bigarray src dst op comm =
-  if ba_kind_is_float (Bigarray.Genarray.kind src) && is_int_only_op op
-  then mpi_error "Mpi.allreduce_bigarray: invalid floating-point operation"
-  else allreduce_bigarray src dst op comm
 
 let allreduce_bigarray0 s d =
   allreduce_bigarray (Bigarray.(genarray_of_array0 s))
@@ -743,10 +725,6 @@ external scan_bigarray:
     ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
     -> 'any op -> communicator -> unit
     = "caml_mpi_scan_bigarray"
-let scan_bigarray src dst op comm =
-  if ba_kind_is_float (Bigarray.Genarray.kind src) && is_int_only_op op
-  then mpi_error "Mpi.scan_bigarray: invalid floating-point operation"
-  else scan_bigarray src dst op comm
 
 let scan_bigarray0 s d = scan_bigarray (Bigarray.(genarray_of_array0 s))
                                        (Bigarray.(genarray_of_array0 d))

--- a/mpi.mli
+++ b/mpi.mli
@@ -350,6 +350,29 @@ val allgather_bigarray1:
            In other terms, [Mpi.allgather] is equivalent to [Mpi.gather]
            at root [r] followed by a broadcast of the result from node [r]. *)
 
+(** All to all *)
+val alltoall: 'a array -> communicator -> 'a array
+val alltoall_int_array: int array -> int array -> communicator -> unit
+val alltoall_float_array: float array -> float array -> communicator -> unit
+val alltoall_bigarray:
+  ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+  -> communicator -> unit
+val alltoall_bigarray1:
+  ('a, 'b, 'c) Bigarray.Array1.t  -> ('a, 'b, 'c) Bigarray.Array1.t
+  -> communicator -> unit
+val alltoall_bigarray2:
+  ('a, 'b, 'c) Bigarray.Array2.t  -> ('a, 'b, 'c) Bigarray.Array2.t
+  -> communicator -> unit
+val alltoall_bigarray3:
+  ('a, 'b, 'c) Bigarray.Array3.t  -> ('a, 'b, 'c) Bigarray.Array3.t
+  -> communicator -> unit
+        (* Using the [Mpi.alltoall*] functions, each process effectively does
+           an [Mpi.scatter*] followed by an [Mpi.gather*]. They can also be
+           seen as an extension to [Mpi.allgather*] where each process sends
+           distinct data to each of the receivers.
+           Both send and receive arrays must have the same size at all
+           nodes. *)
+
 (** Reduce *)
 type intop =
   Int_max | Int_min | Int_sum | Int_prod | Int_land | Int_lor | Int_xor

--- a/mpi.mli
+++ b/mpi.mli
@@ -382,23 +382,31 @@ type _ op =
   | Land : [< `Int ] op
   | Lor  : [< `Int ] op
   | Xor  : [< `Int ] op
-  | Int_max  : [< `Int ] op [@deprecated]
-  | Int_min  : [< `Int ] op [@deprecated]
-  | Int_sum  : [< `Int ] op [@deprecated]
-  | Int_prod : [< `Int ] op [@deprecated]
-  | Int_land : [< `Int ] op [@deprecated]
-  | Int_lor  : [< `Int ] op [@deprecated]
-  | Int_xor  : [< `Int ] op [@deprecated]
-  | Float_max  : [< `Float ] op [@deprecated]
-  | Float_min  : [< `Float ] op [@deprecated]
-  | Float_sum  : [< `Float ] op [@deprecated]
-  | Float_prod : [< `Float ] op [@deprecated]
+  | Int_max  : [< `Int ] op
+  | Int_min  : [< `Int ] op
+  | Int_sum  : [< `Int ] op
+  | Int_prod : [< `Int ] op
+  | Int_land : [< `Int ] op
+  | Int_lor  : [< `Int ] op
+  | Int_xor  : [< `Int ] op
+  | Float_max  : [< `Float ] op
+  | Float_min  : [< `Float ] op
+  | Float_sum  : [< `Float ] op
+  | Float_prod : [< `Float ] op
   (* The operations that can be performed by a reduce or scan; some of
      them are only valid for integers. [Max] and [Min]
      are maximum and minimum; [Sum] and [Prod]
      are summation ([+]) and product ([*]).
      [Land], [Lor] and [Xor] are logical (bit-per-bit) and,
-     or and exclusive-or. *)
+     or and exclusive-or.
+
+     The constructors prefixed by [Int_] or [Float_]
+     (e.g. [Int_max], [Float_sum]) are type-specialized variants of
+     the non-prefixed constructors.  For example, [Int_max] is [Max]
+     specialized to integer values, and [Float_sum] is [Sum]
+     specialized to floating-point values.  These specialized
+     constructors are included for backward compatibility with earlier
+     versions of this library.  They will be deprecated in the future. *)
 
 val reduce_int: int -> [`Int] op -> rank -> communicator -> int
 val reduce_float: float -> [`Float] op -> rank -> communicator -> float
@@ -434,7 +442,7 @@ val reduce_bigarray3:
            are combined using [op] and the result is stored into [dst.(i)]
            at node [root]. For [Mpi.reduce_bigarray*] applied to an array
            of floating-point values, an exception is raised for the
-           [Int_land], [Int_lor] and [Int_xor] operations and the others
+           [Land], [Lor] and [Xor] operations and the others
            are interpreted as floating-point operations. *)
 
 (** Reduce to all *)
@@ -463,8 +471,8 @@ val allreduce_bigarray3:
            corresponding [Mpi.reduce_*] operations, except that the result
            of the reduction is made available at all nodes.
            For [Mpi.allreduce_bigarray*] applied to an array of floating-point
-           values, an exception is raised for the [Int_land], [Int_lor]
-           and [Int_xor] operations and the others are interpreted as
+           values, an exception is raised for the [Land], [Lor]
+           and [Xor] operations and the others are interpreted as
            floating-point operations. *)
 
 (** Scan *)
@@ -499,7 +507,7 @@ val scan_bigarray3:
            argument).  The result is stored in the array passed as second
            argument at the root node. For [Mpi.scan_bigarray*] applied to
            an array of floating-point values, an exception is raised for
-           the [Int_land], [Int_lor] and [Int_xor] operations and the
+           the [Land], [Lor] and [Xor] operations and the
            others are interpreted as floating-point operations. *)
 
 (*** Advanced operations on communicators *)

--- a/mpi.mli
+++ b/mpi.mli
@@ -374,19 +374,34 @@ val alltoall_bigarray3:
            nodes. *)
 
 (** Reduce *)
-type intop =
-  Int_max | Int_min | Int_sum | Int_prod | Int_land | Int_lor | Int_xor
-type floatop =
-  Float_max | Float_min | Float_sum | Float_prod
-        (* The operations that can be performed by a reduce or scan,
-           on integers and floats respectively. [max] and [min]
-           are maximum and minimum; [sum] and [prod]
-           are summation ([+]) and product ([*]).
-           [land]. [lor] and [lxor] are logical (bit-per-bit) and,
-           or and exclusive-or. *)
+type _ op =
+    Max  : [< `Int | `Float ] op
+  | Min  : [< `Int | `Float ] op
+  | Sum  : [< `Int | `Float ] op
+  | Prod : [< `Int | `Float ] op
+  | Land : [< `Int ] op
+  | Lor  : [< `Int ] op
+  | Xor  : [< `Int ] op
+  | Int_max  : [< `Int ] op [@deprecated]
+  | Int_min  : [< `Int ] op [@deprecated]
+  | Int_sum  : [< `Int ] op [@deprecated]
+  | Int_prod : [< `Int ] op [@deprecated]
+  | Int_land : [< `Int ] op [@deprecated]
+  | Int_lor  : [< `Int ] op [@deprecated]
+  | Int_xor  : [< `Int ] op [@deprecated]
+  | Float_max  : [< `Float ] op [@deprecated]
+  | Float_min  : [< `Float ] op [@deprecated]
+  | Float_sum  : [< `Float ] op [@deprecated]
+  | Float_prod : [< `Float ] op [@deprecated]
+  (* The operations that can be performed by a reduce or scan; some of
+     them are only valid for integers. [Max] and [Min]
+     are maximum and minimum; [Sum] and [Prod]
+     are summation ([+]) and product ([*]).
+     [Land], [Lor] and [Xor] are logical (bit-per-bit) and,
+     or and exclusive-or. *)
 
-val reduce_int: int -> intop -> rank -> communicator -> int
-val reduce_float: float -> floatop -> rank -> communicator -> float
+val reduce_int: int -> [`Int] op -> rank -> communicator -> int
+val reduce_float: float -> [`Float] op -> rank -> communicator -> float
         (* [Mpi.reduce_int d op root comm] computes the value of
            [d0 op d1 op ... op dN], where [d0 ... dN] are the values of
            the [d] argument at every node in [comm].  The result value
@@ -395,24 +410,24 @@ val reduce_float: float -> floatop -> rank -> communicator -> float
            except for the use of floating-point operations instead of
            integer operations. *)
 val reduce_int_array:
-  int array -> int array -> intop -> rank -> communicator -> unit
+  int array -> int array -> [`Int] op -> rank -> communicator -> unit
 val reduce_float_array:
-  float array -> float array -> floatop -> rank -> communicator -> unit
+  float array -> float array -> [`Float] op -> rank -> communicator -> unit
 val reduce_bigarray:
   ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
-  -> intop -> rank -> communicator -> unit
+  -> 'any op -> rank -> communicator -> unit
 val reduce_bigarray0:
   ('a, 'b, 'c) Bigarray.Array0.t  -> ('a, 'b, 'c) Bigarray.Array0.t
-  -> intop -> rank -> communicator -> unit
+  -> 'any op -> rank -> communicator -> unit
 val reduce_bigarray1:
   ('a, 'b, 'c) Bigarray.Array1.t  -> ('a, 'b, 'c) Bigarray.Array1.t
-  -> intop -> rank -> communicator -> unit
+  -> 'any op -> rank -> communicator -> unit
 val reduce_bigarray2:
   ('a, 'b, 'c) Bigarray.Array2.t  -> ('a, 'b, 'c) Bigarray.Array2.t
-  -> intop -> rank -> communicator -> unit
+  -> 'any op -> rank -> communicator -> unit
 val reduce_bigarray3:
   ('a, 'b, 'c) Bigarray.Array3.t  -> ('a, 'b, 'c) Bigarray.Array3.t
-  -> intop -> rank -> communicator -> unit
+  -> 'any op -> rank -> communicator -> unit
         (* [Mpi.reduce_int_array d res op root comm] computes 
            [Array.length d] reductions by operation [op] simultaneously.
            For every [i], the values of [d.(i)] at every node
@@ -423,27 +438,27 @@ val reduce_bigarray3:
            are interpreted as floating-point operations. *)
 
 (** Reduce to all *)
-val allreduce_int: int -> intop -> communicator -> int
-val allreduce_float: float -> floatop -> communicator -> float
+val allreduce_int: int -> [`Int] op -> communicator -> int
+val allreduce_float: float -> [`Float] op -> communicator -> float
 val allreduce_int_array:
-  int array -> int array -> intop -> communicator -> unit
+  int array -> int array -> [`Int] op -> communicator -> unit
 val allreduce_float_array:
-  float array -> float array -> floatop -> communicator -> unit
+  float array -> float array -> [`Float] op -> communicator -> unit
 val allreduce_bigarray:
   ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
-  -> intop -> communicator -> unit
+  -> 'any op -> communicator -> unit
 val allreduce_bigarray0:
   ('a, 'b, 'c) Bigarray.Array0.t  -> ('a, 'b, 'c) Bigarray.Array0.t
-  -> intop -> communicator -> unit
+  -> 'any op -> communicator -> unit
 val allreduce_bigarray1:
   ('a, 'b, 'c) Bigarray.Array1.t  -> ('a, 'b, 'c) Bigarray.Array1.t
-  -> intop -> communicator -> unit
+  -> 'any op -> communicator -> unit
 val allreduce_bigarray2:
   ('a, 'b, 'c) Bigarray.Array2.t  -> ('a, 'b, 'c) Bigarray.Array2.t
-  -> intop -> communicator -> unit
+  -> 'any op -> communicator -> unit
 val allreduce_bigarray3:
   ('a, 'b, 'c) Bigarray.Array3.t  -> ('a, 'b, 'c) Bigarray.Array3.t
-  -> intop -> communicator -> unit
+  -> 'any op -> communicator -> unit
         (* The [Mpi.allreduce_*] operations are similar to the
            corresponding [Mpi.reduce_*] operations, except that the result
            of the reduction is made available at all nodes.
@@ -453,31 +468,32 @@ val allreduce_bigarray3:
            floating-point operations. *)
 
 (** Scan *)
-val scan_int: int -> intop -> communicator -> int
-val scan_float: float -> floatop -> communicator -> float
+val scan_int: int -> [`Int] op -> communicator -> int
+val scan_float: float -> [`Float] op -> communicator -> float
         (* [Mpi.scan_int d res op comm] performs a scan operation over
            the integers [d] at every node.  Let [d0 ... dN] be the
            values of the [d] at every node in [comm].  At node with rank [R],
            [Mpi.scan_int d res op comm] returns [d0 op ... op dR].
            [Mpi.scan_float] is similar. *)
-val scan_int_array: int array -> int array -> intop -> communicator -> unit
+val scan_int_array:
+  int array -> int array -> [`Int] op -> communicator -> unit
 val scan_float_array:
-  float array -> float array -> floatop -> communicator -> unit
+  float array -> float array -> [`Float] op -> communicator -> unit
 val scan_bigarray:
   ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
-  -> intop -> communicator -> unit
+  -> 'any op -> communicator -> unit
 val scan_bigarray0:
   ('a, 'b, 'c) Bigarray.Array0.t  -> ('a, 'b, 'c) Bigarray.Array0.t
-  -> intop -> communicator -> unit
+  -> 'any op -> communicator -> unit
 val scan_bigarray1:
   ('a, 'b, 'c) Bigarray.Array1.t  -> ('a, 'b, 'c) Bigarray.Array1.t
-  -> intop -> communicator -> unit
+  -> 'any op -> communicator -> unit
 val scan_bigarray2:
   ('a, 'b, 'c) Bigarray.Array2.t  -> ('a, 'b, 'c) Bigarray.Array2.t
-  -> intop -> communicator -> unit
+  -> 'any op -> communicator -> unit
 val scan_bigarray3:
   ('a, 'b, 'c) Bigarray.Array3.t  -> ('a, 'b, 'c) Bigarray.Array3.t
-  -> intop -> communicator -> unit
+  -> 'any op -> communicator -> unit
         (* Same as [Mpi.scan_int] and [Mpi.scan_float], but perform several
            scanning operations on the elements of the input array (first
            argument).  The result is stored in the array passed as second

--- a/mpi.mli
+++ b/mpi.mli
@@ -21,10 +21,6 @@ exception Error of string
         (* Raised when an operation of the [Mpi] module encounters an error.
            The string argument describes the error. *)
 
-(*** Abbreviations *)
-
-type ('a, 'b) ba1 = ('a, 'b, Bigarray.c_layout) Bigarray.Array1.t
-
 (*** Basic operations on communicators *)
 
 type communicator
@@ -110,8 +106,26 @@ val send_int_array: int array -> rank -> tag -> communicator -> unit
 val receive_int_array: int array -> rank -> tag -> communicator -> unit
 val send_float_array: float array -> rank -> tag -> communicator -> unit
 val receive_float_array: float array -> rank -> tag -> communicator -> unit
-val send_bigarray: ('a, 'b) ba1 -> rank -> tag -> communicator -> unit
-val receive_bigarray: ('a, 'b) ba1 -> rank -> tag -> communicator -> unit
+val send_bigarray:
+  ('a, 'b, 'c) Bigarray.Genarray.t -> rank -> tag -> communicator -> unit
+val send_bigarray0:
+  ('a, 'b, 'c) Bigarray.Array0.t -> rank -> tag -> communicator -> unit
+val send_bigarray1:
+  ('a, 'b, 'c) Bigarray.Array1.t -> rank -> tag -> communicator -> unit
+val send_bigarray2:
+  ('a, 'b, 'c) Bigarray.Array2.t -> rank -> tag -> communicator -> unit
+val send_bigarray3:
+  ('a, 'b, 'c) Bigarray.Array3.t -> rank -> tag -> communicator -> unit
+val receive_bigarray:
+  ('a, 'b, 'c) Bigarray.Genarray.t -> rank -> tag -> communicator -> unit
+val receive_bigarray0:
+  ('a, 'b, 'c) Bigarray.Array0.t -> rank -> tag -> communicator -> unit
+val receive_bigarray1:
+  ('a, 'b, 'c) Bigarray.Array1.t -> rank -> tag -> communicator -> unit
+val receive_bigarray2:
+  ('a, 'b, 'c) Bigarray.Array2.t -> rank -> tag -> communicator -> unit
+val receive_bigarray3:
+  ('a, 'b, 'c) Bigarray.Array3.t -> rank -> tag -> communicator -> unit
         (* Specialized versions of [Mpi.send] and [Mpi.receive]
            for communicating integers, floating-point numbers,
            arrays of integers, arrays of floating-point numbers and
@@ -122,14 +136,19 @@ val receive_bigarray: ('a, 'b) ba1 -> rank -> tag -> communicator -> unit
            meaning as for [Mpi.send].
            The arguments to [Mpi.receive_int] and [Mpi.receive_float]
            have the same meaning as for [Mpi.receive].
-           [Mpi.receive_int_array] and [Mpi.receive_float_array]
+           [Mpi.receive_int_array], [Mpi.receive_float_array] and
+           [Mpi.receive_bigarray*]
            have one extra argument, which is the array in which the data
            of the received message is stored.  The caller is responsible
            for pre-allocating an array large enough to hold the incoming data.
 
            It is an error to send a message using one of the specialized
            [Mpi.send_*] functions and receive it with the generic
-           [Mpi.receive] function, and conversely. *)
+           [Mpi.receive] function, and conversely.
+
+           It is possible to receive a bigarray with different dimensions
+           than those used to send it; only the total number of elements must
+           match. *)
 
 (*** Non-blocking communication *)
 
@@ -203,14 +222,23 @@ val broadcast_int: int -> rank -> communicator -> int
 val broadcast_float: float -> rank -> communicator -> float
 val broadcast_int_array: int array -> rank -> communicator -> unit
 val broadcast_float_array: float array -> rank -> communicator -> unit
-val broadcast_bigarray: ('a, 'b) ba1 -> rank -> communicator -> unit
+val broadcast_bigarray:
+  ('a, 'b, 'c) Bigarray.Genarray.t -> rank -> communicator -> unit
+val broadcast_bigarray0:
+  ('a, 'b, 'c) Bigarray.Array0.t -> rank -> communicator -> unit
+val broadcast_bigarray1:
+  ('a, 'b, 'c) Bigarray.Array1.t -> rank -> communicator -> unit
+val broadcast_bigarray2:
+  ('a, 'b, 'c) Bigarray.Array2.t -> rank -> communicator -> unit
+val broadcast_bigarray3:
+  ('a, 'b, 'c) Bigarray.Array3.t -> rank -> communicator -> unit
         (* Specialized versions of [Mpi.broadcast] for integers, floats,
            arrays of integers, arrays of floats and bigarrays.  For
            [Mpi.broadcast_int] and [Mpi.broadcast_float], the broadcast
            value is returned as result, and the first argument is significant
            only at the root node.
            For [Mpi.broadcast_int_array], [Mpi.broadcast_float_array] and
-           [Mpi.broadcast_bigarray], the broadcast value is stored in the
+           [Mpi.broadcast_bigarray*], the broadcast value is stored in the
            array passed as first argument; thus, the first argument is
            significant at all nodes. *)
 
@@ -224,14 +252,25 @@ val scatter: 'a array -> rank -> communicator -> 'a
            at other nodes. *)
 val scatter_int: int array -> rank -> communicator -> int
 val scatter_float: float array -> rank -> communicator -> float
-val scatter_from_bigarray: ('a, 'b) ba1 -> rank -> communicator -> 'a
+val scatter_from_bigarray:
+  ('a, 'b, 'c) Bigarray.Genarray.t -> rank -> communicator -> 'a
+val scatter_from_bigarray1:
+  ('a, 'b, 'c) Bigarray.Array1.t -> rank -> communicator -> 'a
+val scatter_from_bigarray2:
+  ('a, 'b, 'c) Bigarray.Array2.t -> rank -> communicator -> 'a
+val scatter_from_bigarray3:
+  ('a, 'b, 'c) Bigarray.Array3.t -> rank -> communicator -> 'a
         (* Specialized versions of [Mpi.scatter] for integers, floats and
            values from bigarrays. *)
 val scatter_int_array: int array -> int array -> rank -> communicator -> unit
 val scatter_float_array:
   float array -> float array -> rank -> communicator -> unit
 val scatter_bigarray:
-  ('a, 'b) ba1 -> ('a, 'b) ba1 -> rank -> communicator -> unit
+  ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+  -> rank -> communicator -> unit
+val scatter_bigarray1:
+  ('a, 'b, 'c) Bigarray.Array1.t  -> ('a, 'b, 'c) Bigarray.Array1.t
+  -> rank -> communicator -> unit
         (* Specialized versions of [Mpi.scatter] for arrays of integers,
            arrays of floats and bigarrays.
            [Mpi.scatter_int_array src dst root comm]
@@ -239,7 +278,10 @@ val scatter_bigarray:
            chunks of size [Array.length dst], and sends the chunks to
            each node, storing them into array [dst] at each node.
            The [src] argument is significant only at node [root].
-           [Mpi.scatter_float_array] and [Mpi.scatter_bigarray] are similar. *)
+           [Mpi.scatter_float_array] and [Mpi.scatter_bigarray*] are similar.
+           Use the [Bigarray.genarray_of_array*] functions to, for example,
+           scatter from [n] dimensions to [n-1] dimensions. In any case,
+           only the total number of elements matters. *)
 
 (** Gather *)
 val gather: 'a -> rank -> communicator -> 'a array
@@ -251,32 +293,57 @@ val gather: 'a -> rank -> communicator -> 'a array
            the empty array [[||]] is returned. *)
 val gather_int: int -> int array -> rank -> communicator -> unit
 val gather_float: float -> float array -> rank -> communicator -> unit
-val gather_to_bigarray: 'a -> ('a, 'b) ba1 -> rank -> communicator -> unit
+val gather_to_bigarray:
+  'a -> ('a, 'b, 'c) Bigarray.Genarray.t -> rank -> communicator -> unit
+val gather_to_bigarray1:
+  'a -> ('a, 'b, 'c) Bigarray.Array1.t -> rank -> communicator -> unit
+val gather_to_bigarray2:
+  'a -> ('a, 'b, 'c) Bigarray.Array2.t -> rank -> communicator -> unit
+val gather_to_bigarray3:
+  'a -> ('a, 'b, 'c) Bigarray.Array3.t -> rank -> communicator -> unit
         (* Specialized versions of [Mpi.gather] for integers, floats and
            values to bigarrays. *)
 val gather_int_array: int array -> int array -> rank -> communicator -> unit
 val gather_float_array:
   float array -> float array -> rank -> communicator -> unit
 val gather_bigarray:
-  ('a, 'b) ba1 -> ('a, 'b) ba1 -> rank -> communicator -> unit
+  ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+  -> rank -> communicator -> unit
+val gather_bigarray1:
+  ('a, 'b, 'c) Bigarray.Array1.t  -> ('a, 'b, 'c) Bigarray.Array1.t
+  -> rank -> communicator -> unit
         (* Specialized versions of [Mpi.gather] for arrays of integers,
            arrays of floats and bigarrays.
            [Mpi.gather_int_array src dst root comm]
            sends the arrays [src] at each node to the node [root].
            At node [root], the arrays are concatenated and stored in the
            argument [dst].  [dst] is significant only at node [root].
-           [Mpi.gather_float_array] and [Mpi.gather_bigarray] are similar. *)
+           [Mpi.gather_float_array] and [Mpi.gather_bigarray*] are similar.
+           Use the [Bigarray.genarray_of_array*] functions to, for example,
+           gather from [n-1] dimensions to [n] dimensions. In any case,
+           only the total number of elements matters. *)
 
 (** Gather to all *)
 val allgather: 'a -> communicator -> 'a array
 val allgather_int: int -> int array -> communicator -> unit
 val allgather_float: float -> float array -> communicator -> unit
-val allgather_to_bigarray: 'a -> ('a, 'b) ba1 -> communicator -> unit
+val allgather_to_bigarray:
+  'a -> ('a, 'b, 'c) Bigarray.Genarray.t -> communicator -> unit
+val allgather_to_bigarray1:
+  'a -> ('a, 'b, 'c) Bigarray.Array1.t -> communicator -> unit
+val allgather_to_bigarray2:
+  'a -> ('a, 'b, 'c) Bigarray.Array2.t -> communicator -> unit
+val allgather_to_bigarray3:
+  'a -> ('a, 'b, 'c) Bigarray.Array3.t -> communicator -> unit
 val allgather_int_array: int array -> int array -> communicator -> unit
 val allgather_float_array:
   float array -> float array -> communicator -> unit
 val allgather_bigarray:
-  ('a, 'b) ba1 -> ('a, 'b) ba1 -> communicator -> unit
+  ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+  -> communicator -> unit
+val allgather_bigarray1:
+  ('a, 'b, 'c) Bigarray.Array1.t  -> ('a, 'b, 'c) Bigarray.Array1.t
+  -> communicator -> unit
         (* The [Mpi.allgather*] functions behave like the corresponding
            [Mpi.gather*] functions, except that the result of the gather
            operation is available at all nodes, not only at the root node.
@@ -309,12 +376,25 @@ val reduce_int_array:
 val reduce_float_array:
   float array -> float array -> floatop -> rank -> communicator -> unit
 val reduce_bigarray:
-  ('a, 'b) ba1 -> ('a, 'b) ba1 -> intop -> rank -> communicator -> unit
+  ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+  -> intop -> rank -> communicator -> unit
+val reduce_bigarray0:
+  ('a, 'b, 'c) Bigarray.Array0.t  -> ('a, 'b, 'c) Bigarray.Array0.t
+  -> intop -> rank -> communicator -> unit
+val reduce_bigarray1:
+  ('a, 'b, 'c) Bigarray.Array1.t  -> ('a, 'b, 'c) Bigarray.Array1.t
+  -> intop -> rank -> communicator -> unit
+val reduce_bigarray2:
+  ('a, 'b, 'c) Bigarray.Array2.t  -> ('a, 'b, 'c) Bigarray.Array2.t
+  -> intop -> rank -> communicator -> unit
+val reduce_bigarray3:
+  ('a, 'b, 'c) Bigarray.Array3.t  -> ('a, 'b, 'c) Bigarray.Array3.t
+  -> intop -> rank -> communicator -> unit
         (* [Mpi.reduce_int_array d res op root comm] computes 
            [Array.length d] reductions by operation [op] simultaneously.
            For every [i], the values of [d.(i)] at every node
            are combined using [op] and the result is stored into [dst.(i)]
-           at node [root]. For [Mpi.reduce_bigarray] applied to an array
+           at node [root]. For [Mpi.reduce_bigarray*] applied to an array
            of floating-point values, an exception is raised for the
            [Int_land], [Int_lor] and [Int_xor] operations and the others
            are interpreted as floating-point operations. *)
@@ -327,11 +407,24 @@ val allreduce_int_array:
 val allreduce_float_array:
   float array -> float array -> floatop -> communicator -> unit
 val allreduce_bigarray:
-  ('a, 'b) ba1 -> ('a, 'b) ba1 -> intop -> communicator -> unit
+  ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+  -> intop -> communicator -> unit
+val allreduce_bigarray0:
+  ('a, 'b, 'c) Bigarray.Array0.t  -> ('a, 'b, 'c) Bigarray.Array0.t
+  -> intop -> communicator -> unit
+val allreduce_bigarray1:
+  ('a, 'b, 'c) Bigarray.Array1.t  -> ('a, 'b, 'c) Bigarray.Array1.t
+  -> intop -> communicator -> unit
+val allreduce_bigarray2:
+  ('a, 'b, 'c) Bigarray.Array2.t  -> ('a, 'b, 'c) Bigarray.Array2.t
+  -> intop -> communicator -> unit
+val allreduce_bigarray3:
+  ('a, 'b, 'c) Bigarray.Array3.t  -> ('a, 'b, 'c) Bigarray.Array3.t
+  -> intop -> communicator -> unit
         (* The [Mpi.allreduce_*] operations are similar to the
            corresponding [Mpi.reduce_*] operations, except that the result
            of the reduction is made available at all nodes.
-           For [Mpi.reduce_bigarray] applied to an array of floating-point
+           For [Mpi.allreduce_bigarray*] applied to an array of floating-point
            values, an exception is raised for the [Int_land], [Int_lor]
            and [Int_xor] operations and the others are interpreted as
            floating-point operations. *)
@@ -348,11 +441,24 @@ val scan_int_array: int array -> int array -> intop -> communicator -> unit
 val scan_float_array:
   float array -> float array -> floatop -> communicator -> unit
 val scan_bigarray:
-  ('a, 'b) ba1 -> ('a, 'b) ba1 -> intop -> communicator -> unit
+  ('a, 'b, 'c) Bigarray.Genarray.t  -> ('a, 'b, 'c) Bigarray.Genarray.t
+  -> intop -> communicator -> unit
+val scan_bigarray0:
+  ('a, 'b, 'c) Bigarray.Array0.t  -> ('a, 'b, 'c) Bigarray.Array0.t
+  -> intop -> communicator -> unit
+val scan_bigarray1:
+  ('a, 'b, 'c) Bigarray.Array1.t  -> ('a, 'b, 'c) Bigarray.Array1.t
+  -> intop -> communicator -> unit
+val scan_bigarray2:
+  ('a, 'b, 'c) Bigarray.Array2.t  -> ('a, 'b, 'c) Bigarray.Array2.t
+  -> intop -> communicator -> unit
+val scan_bigarray3:
+  ('a, 'b, 'c) Bigarray.Array3.t  -> ('a, 'b, 'c) Bigarray.Array3.t
+  -> intop -> communicator -> unit
         (* Same as [Mpi.scan_int] and [Mpi.scan_float], but perform several
            scanning operations on the elements of the input array (first
            argument).  The result is stored in the array passed as second
-           argument at the root node. For [Mpi.reduce_bigarray] applied to
+           argument at the root node. For [Mpi.scan_bigarray*] applied to
            an array of floating-point values, an exception is raised for
            the [Int_land], [Int_lor] and [Int_xor] operations and the
            others are interpreted as floating-point operations. *)

--- a/msgs.c
+++ b/msgs.c
@@ -85,10 +85,10 @@ value caml_mpi_send_float(value data, value dest, value tag, value comm)
 value caml_mpi_send_bigarray(value data, value dest, value tag, value comm)
 {
   struct caml_ba_array* d = Caml_ba_array_val(data);
-  mlsize_t len = d->dim[0];
+  mlsize_t dlen = caml_ba_num_elts(d);
   MPI_Datatype dt = caml_mpi_ba_mpi_type[d->flags & CAML_BA_KIND_MASK];
 
-  MPI_Send(d->data, len, dt, Int_val(dest), Int_val(tag), Comm_val(comm));
+  MPI_Send(d->data, dlen, dt, Int_val(dest), Int_val(tag), Comm_val(comm));
   return Val_unit;
 }
 
@@ -200,10 +200,10 @@ value caml_mpi_receive_bigarray(value data, value source, value tag, value comm)
 {
   MPI_Status status;
   struct caml_ba_array* d = Caml_ba_array_val(data);
-  mlsize_t len = d->dim[0];
+  mlsize_t dlen = caml_ba_num_elts(d);
   MPI_Datatype dt = caml_mpi_ba_mpi_type[d->flags & CAML_BA_KIND_MASK];
 
-  MPI_Recv(d->data, len, dt,
+  MPI_Recv(d->data, dlen, dt,
            Int_val(source), Int_val(tag), Comm_val(comm), &status);
   return Val_unit;
 }

--- a/opam
+++ b/opam
@@ -17,7 +17,11 @@ build: [
 ]
 install: [[make "install"]]
 remove: [[make "uninstall"]]
-depends: ["conf-mpi" "ocamlfind"]
+depends: [
+  "conf-mpi"
+  "ocamlfind"
+  "base-bigarray"
+]
 depexts: [
   [["debian"] ["mpi-default-dev"]]
   [["ubuntu"] ["mpi-default-dev"]]

--- a/opam
+++ b/opam
@@ -1,12 +1,11 @@
-opam-version: "1.2"
+opam-version: "2.0"
 version: "1.03"
 maintainer: "xavier.leroy@inria.fr"
 authors: ["Xavier Leroy"]
 homepage: "https://github.com/xavierleroy/ocamlmpi"
 bug-reports: "https://github.com/xavierleroy/ocamlmpi/issues"
 dev-repo: "git://github.com/xavierleroy/ocamlmpi"
-license: "LGPL"
-
+license: "LGPL-2 with OCaml linking exception"
 build: [
   [make "all" "opt"
     "MPIINCDIR=%{conf-mpi:includedir}%"
@@ -18,12 +17,9 @@ build: [
 install: [[make "install"]]
 remove: [[make "uninstall"]]
 depends: [
-  "conf-mpi"
-  "ocamlfind"
+  "ocaml" {>= "4.03.0"}
   "base-bigarray"
+  "conf-mpi"
+  "ocamlfind" {build}
 ]
-depexts: [
-  [["debian"] ["mpi-default-dev"]]
-  [["ubuntu"] ["mpi-default-dev"]]
-]
-available: [ ocaml-version >= "4.02.3" ]
+synopsis: "OCaml binding to the Message Passing Interface (MPI)"

--- a/opam
+++ b/opam
@@ -17,7 +17,7 @@ build: [
 install: [[make "install"]]
 remove: [[make "uninstall"]]
 depends: [
-  "ocaml" {>= "4.03.0"}
+  "ocaml" {>= "4.06.0"}
   "base-bigarray"
   "conf-mpi"
   "ocamlfind" {build}

--- a/test.ml
+++ b/test.ml
@@ -451,6 +451,70 @@ let _ =
                               of_int (myrank*10 + 1);
                               of_int (myrank*10 + 2) |]))
 
+(* Alltoall *)
+
+let test_alltoall msg alltoallfun printfun data =
+  printf "%d: %s alltoall -  sending %a" myrank msg printfun data;
+  print_newline();
+  let res = alltoallfun data comm_world in
+  printf "%d: %s alltoall - received %a" myrank msg printfun res;
+  print_newline();
+  barrier comm_world
+
+let _ =
+  test_alltoall "generic" alltoall (output_array output_string)
+    ([|
+      [| "Un";      "chèque";  "kitch";  "est";      "chique" |];
+      [| "Six";     "scies";   "scient"; "six";      "cigares" |];
+      [| "Elle";    "chausse"; "ses";    "souliers"; "secs" |];
+      [| "Je";      "bois";    "aux";    "trois";    "oies" |];
+      [| "L'œuvre"; "pieuse";  "d'une";  "pieuvre";  "heureuse" |];
+    |]).(myrank);
+  test_alltoall "int"
+    (fun d c -> alltoall_int_array d d c; d)
+    output_int_array
+    ([|
+      [|  0;  1;  2;  3;  4;  5;  6;  7;  8;  9 |];
+      [| 10; 11; 12; 13; 14; 15; 16; 17; 18; 19 |];
+      [| 20; 21; 22; 23; 24; 25; 26; 27; 28; 29 |];
+      [| 30; 31; 32; 33; 34; 35; 36; 37; 38; 39 |];
+      [| 40; 41; 42; 43; 44; 45; 46; 47; 48; 49 |];
+    |]).(myrank);
+  let a = Array.make 5 0.0 in
+  test_alltoall "float"
+    (fun d c -> alltoall_float_array d a c; a)
+    output_float_array
+    ([|
+      [|  1.2;  3.4;  5.6;  7.8;  9.1 |];
+      [| 11.2; 13.4; 15.6; 17.8; 19.1 |];
+      [| 21.2; 23.4; 25.6; 27.8; 29.1 |];
+      [| 31.2; 33.4; 35.6; 37.8; 39.1 |];
+      [| 41.2; 43.4; 45.6; 47.8; 49.1 |];
+    |]).(myrank);
+  let ba = makebigarray1 Char Fortran_layout 5 '@' in
+  test_alltoall "bigarray1(Char)"
+               (fun d c -> alltoall_bigarray1 d ba c; ba)
+               (output_bigarray1 output_char)
+               (tobigarray1 Char Fortran_layout
+                 ([|
+                   [| 'S'; 'A'; 'T'; 'O'; 'R' |];
+                   [| 'a'; 'r'; 'e'; 'p'; 'o' |];
+                   [| 'T'; 'E'; 'N'; 'E'; 'T' |];
+                   [| 'o'; 'p'; 'e'; 'r'; 'a' |];
+                   [| 'R'; 'O'; 'T'; 'A'; 'S' |];
+                 |]).(myrank));
+  let ba = makebigarray2 Int16_unsigned C_layout 5 2 0 in
+  test_alltoall "bigarray2(Int16_unsigned)"
+               (fun d c -> alltoall_bigarray2 d ba c; ba)
+               (output_bigarray2 output_int)
+               (tobigarray2 Int16_unsigned C_layout ([|
+     [| [| 10; 11 |]; [| 12; 13 |]; [| 14; 15 |]; [| 16; 17 |]; [| 18; 19 |] |];
+     [| [| 20; 21 |]; [| 22; 23 |]; [| 24; 25 |]; [| 26; 27 |]; [| 28; 29 |] |];
+     [| [| 30; 31 |]; [| 32; 33 |]; [| 34; 35 |]; [| 36; 37 |]; [| 38; 39 |] |];
+     [| [| 40; 41 |]; [| 42; 43 |]; [| 44; 45 |]; [| 46; 47 |]; [| 48; 49 |] |];
+     [| [| 50; 51 |]; [| 52; 53 |]; [| 54; 55 |]; [| 56; 57 |]; [| 58; 59 |] |];
+                 |]).(myrank))
+
 (* Reduce *)
 
 let name_of_int_reduce = function

--- a/test.ml
+++ b/test.ml
@@ -117,7 +117,9 @@ let output_array fn o a =
 let output_int_array = output_array output_int
 let output_float_array = output_array output_float
 let loop_bounds (type t) (l : t Bigarray.layout) n =
-  match l with C_layout -> 0, n - 1 | Fortran_layout -> 1, n
+  match l with
+    Bigarray.C_layout -> 0, n - 1
+  | Bigarray.Fortran_layout -> 1, n
 let bigarray1_bounds (type t) (a : ('a, 'b, t) Bigarray.Array1.t) =
   loop_bounds (Bigarray.Array1.layout a) (Bigarray.Array1.dim a)
 let output_bigarray0 fn o a =
@@ -147,14 +149,14 @@ let output_bigarray2 (type t) fn o (a : ('a, 'b, t) Bigarray.Array2.t) =
   let n1, n2 = Bigarray.Array2.(dim1 a, dim2 a) in
   output_string o "[ ";
   (match Bigarray.Array2.layout a with
-   | C_layout ->
+   | Bigarray.C_layout ->
        for i = 0 to n1 - 1 do
          if i > 0 then output_string o "; ";
          for j = 0 to n2 - 1 do
            fn o a.{i,j}; output_char o ' '
          done
        done;
-   | Fortran_layout ->
+   | Bigarray.Fortran_layout ->
        for j = 1 to n2 do
          if j > 1 then output_string o "; ";
          for i = 1 to n1 do

--- a/test.ml
+++ b/test.ml
@@ -517,17 +517,23 @@ let _ =
 
 (* Reduce *)
 
-let name_of_int_reduce = function
-    Int_max -> "Int_max"
+let name_of_reduce_op (type t) (x : t op) =
+  match x with
+    Max -> "Max"
+  | Min -> "Min"
+  | Sum -> "Sum"
+  | Prod -> "Prod"
+  | Land -> "Land"
+  | Lor -> "Int_lor"
+  | Xor -> "Int_xor"
+  | Int_max -> "Int_max"
   | Int_min -> "Int_min"
   | Int_sum -> "Int_sum"
   | Int_prod -> "Int_prod"
   | Int_land -> "Int_land"
   | Int_lor -> "Int_lor"
   | Int_xor -> "Int_xor"
-
-let name_of_float_reduce = function
-    Float_max -> "Float_max"
+  | Float_max -> "Float_max"
   | Float_min -> "Float_min"
   | Float_sum -> "Float_sum"
   | Float_prod -> "Float_prod"
@@ -548,39 +554,39 @@ let test_reduce msg reducefun reduceops printfun printop data =
 let _ =
   test_reduce "int"
               reduce_int
-              [Int_max; Int_min; Int_sum; Int_prod; Int_land; Int_lor; Int_xor]
-              output_int name_of_int_reduce
+              [Max; Min; Sum; Prod; Land; Lor; Xor]
+              output_int name_of_reduce_op
               (myrank + 1);
   test_reduce "float"
               reduce_float
-              [Float_max; Float_min; Float_sum; Float_prod]
-              output_float name_of_float_reduce
+              [Max; Min; Sum; Prod]
+              output_float name_of_reduce_op
               (float myrank +. 1.0);
   let ia = Array.make 3 0 in
   test_reduce "int array"
               (fun d op r c -> reduce_int_array d ia op r c; ia)
-              [Int_max; Int_min; Int_sum; Int_prod; Int_land; Int_lor; Int_xor]
-              output_int_array name_of_int_reduce
+              [Max; Min; Sum; Prod; Land; Lor; Xor]
+              output_int_array name_of_reduce_op
               [| myrank * 10; myrank * 10 + 1; myrank * 10 + 2 |];
   let fa = Array.make 3 0.0 in
   test_reduce "float array"
               (fun d op r c -> reduce_float_array d fa op r c; fa)
-              [Float_max; Float_min; Float_sum; Float_prod]
-              output_float_array name_of_float_reduce
+              [Max; Min; Sum; Prod]
+              output_float_array name_of_reduce_op
               [| float myrank; float myrank +. 0.1; float myrank +. 0.2 |];
   let ba = makebigarray1 Int8_unsigned C_layout 3 0 in
-  (* note: result of Int_prod is [0 225 0] due to 8-bit precision *)
+  (* note: result of Prod is [0 225 0] due to 8-bit precision *)
   test_reduce "bigarray1(Int8_unsigned)"
               (fun d op r c -> reduce_bigarray1 d ba op r c; ba)
-              [Int_max; Int_min; Int_sum; Int_prod; Int_land; Int_lor; Int_xor]
-              (output_bigarray1 output_int) name_of_int_reduce
+              [Max; Min; Sum; Prod; Land; Lor; Xor]
+              (output_bigarray1 output_int) name_of_reduce_op
               (tobigarray1 Int8_unsigned C_layout
                 [| myrank * 10; myrank * 10 + 1; myrank * 10 + 2 |]);
   let ba = makebigarray2 Int16_unsigned C_layout 2 3 0 in
   test_reduce "bigarray2(Int16_unsigned)"
               (fun d op r c -> reduce_bigarray2 d ba op r c; ba)
-              [Int_max; Int_min; Int_sum; Int_prod; Int_land; Int_lor; Int_xor]
-              (output_bigarray2 output_int) name_of_int_reduce
+              [Max; Min; Sum; Prod; Land; Lor; Xor]
+              (output_bigarray2 output_int) name_of_reduce_op
               (tobigarray2 Int16_unsigned C_layout
                 [| [| myrank * 10; myrank * 10 + 1; myrank * 10 + 2 |];
                    [| myrank * 20; myrank * 20 + 1; myrank * 20 + 2 |] |])
@@ -597,29 +603,29 @@ let test_reduceall msg reducefun reduceop printfun data =
 
 let _ =
   test_reduceall "int"
-              allreduce_int Int_sum
+              allreduce_int Sum
               output_int
               (myrank + 1);
   test_reduceall "float"
-              allreduce_float Float_prod
+              allreduce_float Prod
               output_float
               (float myrank +. 1.0);
   let ia = Array.make 3 0 in
   test_reduceall "int array"
               (fun d op c -> allreduce_int_array d ia op c; ia)
-              Int_sum
+              Sum
               output_int_array
               [| myrank * 10; myrank * 10 + 1; myrank * 10 + 2 |];
   let fa = Array.make 3 0.0 in
   test_reduceall "float array"
               (fun d op c -> allreduce_float_array d fa op c; fa)
-              Float_sum
+              Sum
               output_float_array
               [| float myrank; float myrank +. 0.1; float myrank +. 0.2 |];
   let ba = makebigarray1 Complex32 C_layout 3 Complex.zero in
   test_reduceall "bigarray1(Complex32)"
               (fun d op c -> allreduce_bigarray1 d ba op c; ba)
-              Int_sum
+              Sum
               (output_bigarray1 output_complex)
               (tobigarray1 Complex32 C_layout
                 [| cx (float myrank +. 0.25) (float myrank +. 0.25);
@@ -640,31 +646,31 @@ let test_scan msg scanfun reduceop printfun data =
 let _ =
   test_scan "int"
               scan_int
-              Int_sum
+              Sum
               output_int
               (myrank + 1);
   test_scan "float"
               scan_float
-              Float_sum
+              Sum
               output_float
               (float myrank +. 1.0);
   let ia = Array.make 3 0 in
   test_scan "int array"
               (fun d op c -> scan_int_array d ia op c; ia)
-              Int_sum
+              Sum
               output_int_array
               [| myrank * 10; myrank * 10 + 1; myrank * 10 + 2 |];
   let fa = Array.make 3 0.0 in
   test_scan "float array"
               (fun d op c -> scan_float_array d fa op c; fa)
-              Float_sum
+              Sum
               output_float_array
               [| float myrank; float myrank +. 0.1; float myrank +. 0.2 |];
   let ba = makebigarray1 Int32 C_layout 3 0l in
   let r = Int32.of_int myrank in
   test_scan "bigarray1(Int32)"
               (fun d op c -> scan_bigarray1 d ba op c; ba)
-              Int_sum
+              Sum
               (output_bigarray1 output_int32)
               (tobigarray1 Int32 C_layout Int32.(
                 [| mul r 10l; add (mul r 10l) 1l; add (mul r 10l) 2l |]))

--- a/utils.c
+++ b/utils.c
@@ -18,6 +18,8 @@
 #include <mpi.h>
 #include <caml/mlvalues.h>
 #include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/bigarray.h>
 #include "camlmpi.h"
 
 void caml_mpi_decode_intarray(value data, mlsize_t len)
@@ -30,6 +32,91 @@ void caml_mpi_encode_intarray(value data, mlsize_t len)
 {
   mlsize_t i;
   for (i = 0; i < len; i++) Field(data, i) = Val_long(Field(data, i));
+}
+
+static value copy_two_doubles(double d0, double d1)
+{
+  value res = caml_alloc_small(2 * Double_wosize, Double_array_tag);
+  Store_double_field(res, 0, d0);
+  Store_double_field(res, 1, d1);
+  return res;
+}
+
+value caml_mpi_ba_value(any_ba_value(dv), intnat kind)
+{
+  void *d = dv;
+
+  switch (kind) {
+  default:
+    CAMLassert(0);
+  case CAML_BA_FLOAT32:
+    return caml_copy_double((double) *((float*) d));
+  case CAML_BA_FLOAT64:
+    return caml_copy_double(*((double *) d));
+  case CAML_BA_SINT8:
+    return Val_int(*((caml_ba_int8 *) d));
+  case CAML_BA_UINT8:
+    return Val_int(*((caml_ba_uint8 *) d));
+  case CAML_BA_SINT16:
+    return Val_int(*((caml_ba_int16 *) d));
+  case CAML_BA_UINT16:
+    return Val_int(*((caml_ba_uint16 *) d));
+  case CAML_BA_INT32:
+    return caml_copy_int32(*((int32_t *) d));
+  case CAML_BA_INT64:
+    return caml_copy_int64(*((int64_t *) d));
+  case CAML_BA_NATIVE_INT:
+    return caml_copy_nativeint(*((intnat *) d));
+  case CAML_BA_CAML_INT:
+    return Val_long(*((intnat *) d));
+  case CAML_BA_COMPLEX32:
+    { float * p = (float *) d;
+      return copy_two_doubles((double) p[0], (double) p[1]); }
+  case CAML_BA_COMPLEX64:
+    { double * p = (double *) d;
+      return copy_two_doubles(p[0], p[1]); }
+  case CAML_BA_CHAR:
+    return Val_int(*((unsigned char *) d));
+  }
+}
+
+void caml_mpi_ba_element(value dv, intnat kind, any_ba_value(rv))
+{
+  void *r = rv;
+
+  switch (kind) {
+  default:
+    CAMLassert(0);
+  case CAML_BA_FLOAT32:
+    *((float *) r) = Double_val(dv); break;
+  case CAML_BA_FLOAT64:
+    *((double *) r) = Double_val(dv); break;
+  case CAML_BA_CHAR:
+  case CAML_BA_SINT8:
+  case CAML_BA_UINT8:
+    *((caml_ba_int8 *) r) = Int_val(dv); break;
+  case CAML_BA_SINT16:
+  case CAML_BA_UINT16:
+    *((caml_ba_int16 *) r) = Int_val(dv); break;
+  case CAML_BA_INT32:
+    *((int32_t *) r) = Int32_val(dv); break;
+  case CAML_BA_INT64:
+    *((int64_t *) r) = Int64_val(dv); break;
+  case CAML_BA_NATIVE_INT:
+    *((intnat *) r) = Nativeint_val(dv); break;
+  case CAML_BA_CAML_INT:
+    *((intnat *) r) = Long_val(dv); break;
+  case CAML_BA_COMPLEX32:
+    { float * p = ((float *) r);
+      p[0] = Double_field(dv, 0);
+      p[1] = Double_field(dv, 1);
+      break; }
+  case CAML_BA_COMPLEX64:
+    { double * p = ((double *) r);
+      p[0] = Double_field(dv, 0);
+      p[1] = Double_field(dv, 1);
+      break; }
+  }
 }
 
 #ifdef ARCH_ALIGN_DOUBLE
@@ -82,3 +169,4 @@ double * caml_mpi_output_floatarray_at_node(value data, mlsize_t len,
 }
 
 #endif
+


### PR DESCRIPTION
Hello @xavierleroy,

I'm working on updating the Sundials/ML library. The new version requires `Mpi.allreduce` on "nvectors" which are interfaced using bigarrays, so I would like to add an `allreduce_bigarray` operation to ocamlmpi. This pull request is a first proposal. I added bigarray versions of other operations for good measure.

The only potential drawback of this addition is that it requires adding `bigarray.cm(x)a` to the command-line when compiling applications under older versions of OCaml. This does not seem to be required for newer OCaml versions (tested on 4.10.0).

The `(all)reduce_bigarray` calls take an `intop` even when the bigarray argument contains a floating-point or complex value and there is a dynamic check to rule out invalid operations. This is a bit ugly, but maybe using a GADT here would be overkill?

Best regards,

Tim.