### PR TITLE
Upgrade to OCaml 5.2

### DIFF
--- a/mpi.ml
+++ b/mpi.ml
@@ -21,6 +21,7 @@ exception Error of string
 let ba_kind_is_float (type a b) (k : (a, b) Bigarray.kind) =
   let open Bigarray in
   match k with
+  | Float16 -> true
   | Float32 -> true
   | Float64 -> true
   | Complex32 -> true

--- a/opam
+++ b/opam
@@ -17,7 +17,7 @@ build: [
 install: [[make "install"]]
 remove: [[make "uninstall"]]
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "5.2.0"}
   "base-bigarray"
   "conf-mpi"
   "ocamlfind" {build}


### PR DESCRIPTION
OCaml 5.2 added support for float16 bigarrays, this change breaks ocamlmpi when using `OCAMLPARAM=warn-error=+8,_`. While not strictly necessary i would argue applying this change in one form or another would be an improvement in terms of quality.
```
#=== ERROR while compiling mpi.1.05 ===========================================#
# context              2.2.0~beta2~dev | linux/x86_64 | ocaml-variants.5.2.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/5.2/.opam-switch/build/mpi.1.05
# command              /usr/bin/make all opt MPIINCDIR=/usr/lib/x86_64-linux-gnu/openmpi/include MPILIBDIR=/usr/lib/x86_64-linux-gnu/openmpi/lib/lib MPICC=/usr/lib/x86_64-linux-gnu/openmpi/lib/bin/mpicc MPIRUN=/usr/lib/x86_64-linux-gnu/openmpi/lib/bin/mpirun
# exit-code            2
# env-file             ~/.opam/log/mpi-19-86ce85.env
# output-file          ~/.opam/log/mpi-19-86ce85.out
### output ###
# cc -I`ocamlc -where` -I/usr/lib/x86_64-linux-gnu/openmpi/include -O2 -g -Wall -DCAML_NAME_SPACE   -c -o init.o init.c
# cc -I`ocamlc -where` -I/usr/lib/x86_64-linux-gnu/openmpi/include -O2 -g -Wall -DCAML_NAME_SPACE   -c -o comm.o comm.c
# cc -I`ocamlc -where` -I/usr/lib/x86_64-linux-gnu/openmpi/include -O2 -g -Wall -DCAML_NAME_SPACE   -c -o msgs.o msgs.c
# msgs.c: In function 'caml_mpi_send_intarray':
# msgs.c:70:12: warning: passing argument 1 of 'MPI_Send' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#    70 |   MPI_Send(&Field(data, 0), Wosize_val(data), MPI_LONG,
# In file included from msgs.c:18:
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1808:41: note: expected 'const void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1808 | OMPI_DECLSPEC  int MPI_Send(const void *buf, int count, MPI_Datatype datatype, int dest,
#       |                             ~~~~~~~~~~~~^~~
# msgs.c: In function 'caml_mpi_receive_intarray':
# msgs.c:172:12: warning: passing argument 1 of 'MPI_Recv' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   172 |   MPI_Recv(&Field(data, 0), Wosize_val(data), MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1747:35: note: expected 'void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1747 | OMPI_DECLSPEC  int MPI_Recv(void *buf, int count, MPI_Datatype datatype, int source,
#       |                             ~~~~~~^~~
# cc -I`ocamlc -where` -I/usr/lib/x86_64-linux-gnu/openmpi/include -O2 -g -Wall -DCAML_NAME_SPACE   -c -o collcomm.o collcomm.c
# collcomm.c: In function 'caml_mpi_broadcast_intarray':
# collcomm.c:58:13: warning: passing argument 1 of 'MPI_Bcast' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#    58 |   MPI_Bcast(&Field(data, 0), Wosize_val(data), MPI_LONG,
# In file included from collcomm.c:18:
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1369:36: note: expected 'void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1369 | OMPI_DECLSPEC  int MPI_Bcast(void *buffer, int count, MPI_Datatype datatype,
#       |                              ~~~~~~^~~~~~
# collcomm.c: In function 'caml_mpi_scatter_int':
# collcomm.c:126:15: warning: passing argument 1 of 'MPI_Scatter' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   126 |   MPI_Scatter(&Field(data, 0), 1, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1793:44: note: expected 'const void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1793 | OMPI_DECLSPEC  int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
#       |                                ~~~~~~~~~~~~^~~~~~~
# collcomm.c: In function 'caml_mpi_scatter_intarray':
# collcomm.c:169:15: warning: passing argument 1 of 'MPI_Scatter' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   169 |   MPI_Scatter(&Field(source, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1793:44: note: expected 'const -       |                   ^
void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1793 | OMPI_DECLSPEC  int MPI_Scatter(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
#       |                                ~~~~~~~~~~~~^~~~~~~
# collcomm.c:170:15: warning: passing argument 4 of 'MPI_Scatter' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   170 |               &Field(dest, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1794:38: note: expected 'void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1794 |                                void *recvbuf, int recvcount, MPI_Datatype recvtype,
#       |                                ~~~~~~^~~~~~~
# collcomm.c: In function 'caml_mpi_gather_int':
# collcomm.c:233:14: warning: passing argument 4 of 'MPI_Gather' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   233 |              &Field(result, 0), 1, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1578:37: note: expected 'void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1578 |                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
#       |                               ~~~~~~^~~~~~~
# collcomm.c: In function 'caml_mpi_gather_intarray':
# collcomm.c:242:14: warning: passing argument 1 of 'MPI_Gather' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   242 |   MPI_Gather(&Field(data, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1577:43: note: expected 'const void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1577 | OMPI_DECLSPEC  int MPI_Gather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
#       |                               ~~~~~~~~~~~~^~~~~~~
# collcomm.c:243:14: warning: passing argument 4 of 'MPI_Gather' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   243 |              &Field(result, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1578:37: note: expected 'void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1578 |                               void *recvbuf, int recvcount, MPI_Datatype recvtype,
#       |                               ~~~~~~^~~~~~~
# collcomm.c: In function 'caml_mpi_allgather_int':
# collcomm.c:326:17: warning: passing argument 4 of 'MPI_Allgather' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   326 |                 &Field(result, 0), 1, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1332:40: note: expected 'void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1332 |                                  void *recvbuf, int recvcount,
#       |                                  ~~~~~~^~~~~~~
# collcomm.c: In function 'caml_mpi_allgather_intarray':
# collcomm.c:334:17: warning: passing argument 1 of 'MPI_Allgather' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   334 |   MPI_Allgather(&Field(data, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1331:46: note: expected 'const void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1331 | OMPI_DECLSPEC  int MPI_Allgather(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
#       |                                  ~~~~~~~~~~~~^~~~~~~
# collcomm.c:335:17: warning: passing argument 4 of 'MPI_Allgather' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   335 |                 &Field(result, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1332:40: note: expected 'void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1332 |                                  void *recvbuf, int recvcount,
#       |                                  ~~~~~~^~~~~~~
# collcomm.c: In function 'caml_mpi_alltoall_intarray':
# collcomm.c:417:19: warning: initialization discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   417 |   void* sendbuf = &Field(data, 0);
#       |                   ^
# collcomm.c:418:19: warning: initialization discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   418 |   void* recvbuf = &Field(result, 0);
#       |                   ^
# collcomm.c: In function 'caml_mpi_reduce_intarray':
# collcomm.c:497:14: warning: passing argument 1 of 'MPI_Reduce' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   497 |   MPI_Reduce(&Field(data, 0), &Field(result, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1749:43: note: expected 'const void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1749 | OMPI_DECLSPEC  int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
#       |                               ~~~~~~~~~~~~^~~~~~~
# collcomm.c:497:31: warning: passing argument 2 of 'MPI_Reduce' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   497 |   MPI_Reduce(&Field(data, 0), &Field(result, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1749:58: note: expected 'void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1749 | OMPI_DECLSPEC  int MPI_Reduce(const void *sendbuf, void *recvbuf, int count,
#       |                                                    ~~~~~~^~~~~~~
# collcomm.c: In function 'caml_mpi_allreduce_intarray':
# collcomm.c:572:17: warning: passing argument 1 of 'MPI_Allreduce' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   572 |   MPI_Allreduce(&Field(data, 0), &Field(result, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1345:46: note: expected 'const void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1345 | OMPI_DECLSPEC  int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
#       |                                  ~~~~~~~~~~~~^~~~~~~
# collcomm.c:572:34: warning: passing argument 2 of 'MPI_Allreduce' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   572 |   MPI_Allreduce(&Field(data, 0), &Field(result, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1345:61: note: expected 'void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1345 | OMPI_DECLSPEC  int MPI_Allreduce(const void *sendbuf, void *recvbuf, int count,
#       |                                                       ~~~~~~^~~~~~~
# collcomm.c: In function 'caml_mpi_scan_intarray':
# collcomm.c:639:12: warning: passing argument 1 of 'MPI_Scan' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   639 |   MPI_Scan(&Field(data, 0), &Field(result, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1789:41: note: expected 'const void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1789 | OMPI_DECLSPEC  int MPI_Scan(const void *sendbuf, void *recvbuf, int count,
#       |                             ~~~~~~~~~~~~^~~~~~~
# collcomm.c:639:29: warning: passing argument 2 of 'MPI_Scan' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
#   639 |   MPI_Scan(&Field(data, 0), &Field(result, 0), len, MPI_LONG,
# /usr/lib/x86_64-linux-gnu/openmpi/include/mpi.h:1789:56: note: expected 'void *' but argument is of type 'volatile value *' {aka 'volatile long int *'}
#  1789 | OMPI_DECLSPEC  int MPI_Scan(const void *sendbuf, void *recvbuf, int count,
#       |                                                  ~~~~~~^~~~~~~
# cc -I`ocamlc -where` -I/usr/lib/x86_64-linux-gnu/openmpi/include -O2 -g -Wall -DCAML_NAME_SPACE   -c -o groups.o groups.c
# cc -I`ocamlc -where` -I/usr/lib/x86_64-linux-gnu/openmpi/include -O2 -g -Wall -DCAML_NAME_SPACE   -c -o utils.o utils.c
# rm -f libcamlmpi.a
# ar rc libcamlmpi.a init.o comm.o msgs.o collcomm.o groups.o utils.o
# ocamlc -c mpi.mli
# ocamlc -c mpi.ml
# File "mpi.ml", lines 23-36, characters 2-17:
# 23 | ..match k with
# 24 |   | Float32 -> true
# 25 |   | Float64 -> true
# 26 |   | Complex32 -> true
# 27 |   | Complex64 -> true
# ...
# 33 |   | Int64 -> false
# 34 |   | Int -> false
# 35 |   | Nativeint -> false
# 36 |   | Char -> false
# Error (warning 8 [partial-match]): this pattern-matching is not exhaustive.
# Here is an example of a case that is not matched:
# Float16
# make: *** [Makefile:37: mpi.cmo] Error 2
```